### PR TITLE
#68 - core: revisit format

### DIFF
--- a/src/core/format.l
+++ b/src/core/format.l
@@ -4,77 +4,117 @@
 ;;;
 ;;; core format
 ;;;
+(mu:intern core::ns :intern "fmt-tilde"
+  (:lambda (dest args)
+    (core:write-char #\~ dest)
+    args))
+
+(mu:intern core::ns :intern "fmt-percent"
+  (:lambda (dest args)
+    (core:terpri dest)
+    args))
+
+(mu:intern core::ns :intern "fmt-decimal"
+  (:lambda (dest args)
+    (core:errorp-unless core:fixnump (mu:car args) "format: argument to ~D not a fixnum")
+    (core:write (mu:car args) () dest)
+    (mu:cdr args)))
+
+(mu:intern core::ns :intern "fmt-hex"
+  (:lambda (dest args)
+    ((:lambda (fx)
+       (core:errorp-unless core:fixnump fx "format: argument to ~X not a fixnum")
+       (core:errorp-when (:lambda (n) (mu:fx-lt n 0)) fx "format: argument to ~X is negative")
+       (:if (core:zerop fx)
+            (core:write "0" () dest)
+            ((:lambda (loop)
+               ((:lambda (lst)
+                  (core:mapc (:lambda (ch) (core:write ch () dest))
+                             (mu:nthcdr (core:positionl
+                                         (:lambda (item elt)
+                                           (core:null (mu:eq item elt)))
+                                         #\0
+                                         lst)
+                                        lst)))
+                (loop loop fx 14)))
+             (:lambda (loop fx nth)
+               (:if (core:zerop nth)
+                    ()
+                    (core::append (loop loop (core:ash fx -4) (core:1- nth))
+                                  (core::list (core:schar "0123456789abcdef" (mu:logand fx #xf))))))))
+       (mu:cdr args))
+     (mu:car args))))
+
+(mu:intern core::ns :intern "fmt-aesthetic"
+  (:lambda (dest args)
+    (core:write (mu:car args) () dest)
+    (mu:cdr args)))
+
+(mu:intern core::ns :intern "fmt-standard"
+  (:lambda (dest args)
+    (core:write (mu:car args) :t dest)
+    (mu:cdr args)))
+
+;;;
+;;; control ops
+;;;
+(mu:intern core::ns :intern "fmt-op-table"
+  (:lambda (ch)
+    (mu:cdr
+      (core:assoc
+       ch
+       '((#\A . core::fmt-aesthetic)
+         (#\S . core::fmt-standard)
+         (#\X . core::fmt-hex)
+         (#\D . core::fmt-decimal)
+         (#\~ . core::fmt-tilde)
+         (#\% . core::fmt-percent))))))
+
+(mu:intern core::ns :intern "fmt-op"
+  (:lambda (dir dest args)
+    ((:lambda (fn)
+       (:if fn
+            (core:apply (mu:sy-val fn) (core::list2 dest args))
+            (core:error dir "core:format: unrecognized format directive")))
+     (core::fmt-op-table dir))))
+
+(mu:intern core::ns :intern "fmt-loop"
+  (:lambda (stream dest fmt args)
+    (mu:fix
+     (:lambda (loop)
+       ((:lambda (nth argl)
+          (:if (mu:eq nth (core:length fmt))
+               loop
+               ((:lambda (ch)
+                  (:if (mu:eq ch #\~)
+                       (core::prog2
+                           (core:error-if (mu:eq (core:1+ nth) (core:length fmt)) nth "core:format: unexpected end of string")
+                           (mu:cons (mu:fx-add 2 nth) (core::fmt-op (core:schar fmt (core:1+ nth)) dest argl)))
+                       (core::prog2
+                           (core:write-char ch dest)
+                           (mu:cons (core:1+ nth) argl))))
+                (core:schar fmt nth))))
+        (mu:car loop)
+        (mu:cdr loop)))
+     (mu:cons 0 args))
+    (:if (core:null stream)
+         (core:get-output-stream-string dest)
+         ())))
+
 (mu:intern core::ns :extern "format"
    (:lambda (stream fmt args)
      (core:errorp-unless core:stringp fmt "core:format: not a string")
      (core:errorp-unless core:listp args "core:format: not a list")
-     ((:lambda (dest fmt-len fmt-op)
-        (:if (core:zerop fmt-len)
-              (:if stream
-                   ""
-                   ())
-              ((:lambda ()
-                 (mu:fix
-                  (:lambda (self nth args)
-                    (:if (mu:eq nth fmt-len)
-                         dest
-                         ((:lambda (ch)
-                            (:if (mu:eq ch #\~)
-                                 ((:lambda ()
-                                    (core:error-if (mu:eq (core:1+ nth) fmt-len) nth "core:format: end of string while processing directive")
-                                    (mu:fr-setv (core::fn-frame-id self) 2 (fmt-op (core:schar fmt (core:1+ nth)) dest args))
-                                    (mu:fr-setv (core::fn-frame-id self) 1 (mu:fx-add 2 nth))))
-                                 (core::prog2
-                                    (core:write-char ch dest)
-                                    (mu:fr-setv (core::fn-frame-id self) 1 (core:1+ nth)))))
-                          (core:schar fmt nth))))
-                  (core::list2 0 args))
-                 (:if (core:null stream)
-                      (core:get-output-stream-string dest)
-                      ())))))
-       (:if (core:null stream)
-            (mu:open :string :output "")
-            (:if (mu:eq stream :t)
-                 mu:std-out
-                 (:if (core:streamp stream)
-                      stream
-                      (core:error stream "core:format: not a stream designator"))))
-       (core:length fmt)
-       (:lambda (dir dest args)
-         (:if (mu:eq dir #\~)
-              (core::prog2 (core:write-char #\~ dest) args)
-              (:if (mu:eq dir #\%)
-                   (core::prog2 (core:terpri dest) args)
-                   (:if (mu:eq dir #\D)
-                        ((:lambda ()
-                           (core:errorp-unless core:fixnump (mu:car args) "format: argument to ~D not a fixnum")
-                           (core:write (mu:car args) () dest)
-                           (mu:cdr args)))
-                        (:if (mu:eq dir #\X)
-                             ((:lambda (fx)
-                                (core:errorp-unless core:fixnump fx "format: argument to ~X not a fixnum")
-                                (core:errorp-when (:lambda (n) (mu:fx-lt n 0)) fx "format: argument to ~X is negative")
-                                (:if (core:zerop fx)
-                                     (core:write "0" () dest)
-                                     ((:lambda (loop)
-                                        ((:lambda (lst)
-                                           (core:mapc (:lambda (ch) (core:write ch () dest))
-                                                      (mu:nthcdr (core:positionl
-                                                                  (:lambda (item elt)
-                                                                    (core:null (mu:eq item elt)))
-                                                                  #\0
-                                                                  lst)
-                                                                 lst)))
-                                           (loop loop fx 14)))
-                                      (:lambda (loop fx nth)
-                                        (:if (core:zerop nth)
-                                             ()
-                                             (core::append (loop loop (core:ash fx -4) (core:1- nth))
-                                                           (core::list (core:schar "0123456789abcdef" (mu:logand fx #xf))))))))
-                                (mu:cdr args))
-                              (mu:car args))
-                             (:if (mu:eq dir #\A)
-                                  (core::prog2 (core:write (mu:car args) () dest) (mu:cdr args))
-                                  (:if (mu:eq dir #\S)
-                                       (core::prog2 (core:write (mu:car args) :t dest) (mu:cdr args))
-                                       (core:error dir "core:format: unrecognized format directive")))))))))))
+
+     (:if (core:zerop (core:length fmt))
+          (:if stream
+               ""
+               ())
+          ((:lambda (dest) (core::fmt-loop stream dest fmt args))
+           (:if (core:null stream)
+                (mu:open :string :output "")
+                (:if (mu:eq stream :t)
+                     mu:std-out
+                     (:if (core:streamp stream)
+                          stream
+                          (core:error stream "core:format: not a stream designator"))))))))

--- a/src/core/lists.l
+++ b/src/core/lists.l
@@ -107,15 +107,15 @@
      (core:errorp-unless core:listp list "core:maplist: not a list")
      (mu:car
       (mu:fix
-       (:lambda (desc)
+       (:lambda (loop)
          ((:lambda (acc lst)
             (:if lst
                  (mu:cons
                   (core::append acc (core::list (core::apply fn (core::list lst))))
                   (mu:cdr lst))
-                 desc))
-          (mu:car desc)
-          (mu:cdr desc)))
+                 loop))
+          (mu:car loop)
+          (mu:cdr loop)))
        (mu:cons () list)))))
 
 ;;;

--- a/src/mu/types/stream.rs
+++ b/src/mu/types/stream.rs
@@ -539,14 +539,17 @@ impl Core for Stream {
                 let stream_id = Fixnum::as_i64(mu, image.source) as usize;
                 SystemStream::write_byte(system_stream, stream_id, byte)
             }
-            Type::Cons => {
+            Type::Null | Type::Cons => {
                 image.source = Cons::new(Fixnum::as_tag(byte as i64), image.source).evict(mu);
                 image.count = Fixnum::as_tag(Fixnum::as_i64(mu, image.count) + 1);
                 Self::update(mu, &image, stream);
 
                 Ok(None)
             }
-            _ => panic!("internal: stream state inconsistency"),
+            _ => panic!(
+                "internal: {:?} stream state inconsistency",
+                Tag::type_of(mu, image.source)
+            ),
         }
     }
 }

--- a/tests/core/format
+++ b/tests/core/format
@@ -3,11 +3,11 @@
 #
 assert_eq "(mu:type-of core:format)" ":func"
 assert_eq "(core:format :t \"core:format\" ())" "core:format:nil"
-assert_eq "(core:format () \"core:format\" ())" "core:format"
+assert_eq "(core:format () \"core:format\" ())" '"core:format"'
 assert_eq "(core:stringp (core:format () \"core:format\" ()))" ":t"
 assert_eq "(core:format :t \"core:format unqualified ~A symbol arg\" '(f-symbol))" "core:format unqualified f-symbol symbol arg:nil"
-assert_eq "(core:format :t \"core:format unqualified ~S symbol arg\" '(f-symbol))" "core:format unqualified #:f-symbol symbol arg:nil"
-assert_eq "(core:format :t \"core:format qualified ~A symbol arg\" '(mu:fx-add))" "core:format qualified fixnum+ symbol arg:nil"
+assert_eq "(core:format :t \"core:format unqualified ~S symbol arg\" '(f-symbol))" "core:format unqualified f-symbol symbol arg:nil"
+assert_eq "(core:format :t \"core:format qualified ~A symbol arg\" '(mu:fx-add))" "core:format qualified fx-add symbol arg:nil"
 assert_eq "(core:format :t \"core:format qualified ~S symbol arg\" '(mu:fx-add))" "core:format qualified mu:fx-add symbol arg:nil"
 assert_eq "(core:format :t \"core:format ~A string arg\" '(\"f-string\"))" "core:format f-string string arg:nil"
 assert_eq "(core:format :t \"core:format ~S string arg\" '(\"f-string\"))" "core:format \"f-string\" string arg:nil"


### PR DESCRIPTION
Rework format so that it actually works

Doc: no change
Tests: fiddle format tests, all pass
Mu: no change
Core: format.l gets restructured