### PR TITLE
#70 - core: fix strings

### DIFF
--- a/src/core/exceptions.l
+++ b/src/core/exceptions.l
@@ -20,10 +20,11 @@
       ((:lambda (fn args)
          (core:format :t
                 "(~A ~A)~%"
-                (core::list2 (:if (core:symbolp (core::fn-form fn))
-                              (core::fn-form fn)
-                              (core::string-append :intern "lambda-" (core:symbol-name (core::fn-frame-id fn))))
-                             (core:sv-list args))))
+                (core::list2
+                 (:if (core:symbolp (core::fn-form fn))
+                      (core::fn-form fn)
+                      (core::string-append :intern "lambda-" (core:symbol-name (core::fn-frame-id fn))))
+                 (core:sv-list args))))
        (mu:car frame)
        (mu:cdr frame))))
 

--- a/src/core/strings.l
+++ b/src/core/strings.l
@@ -27,18 +27,17 @@
       (:if (mu:eq str-1 str-2)
          :t
          (:if (mu:eq (mu:sv-len str-1) (mu:sv-len str-2))
-            ((:lambda (result)
-               (core:charp result))
-             (core:foldl
-               (:lambda (el acc)
-                  (:if (core:null acc)
-                       ()
-                       (:if (mu:eq el (mu:sv-ref str-2 acc))
-                            (core:1+ acc)
-                            ())))
-                  0
-                  str-1))
-            ()))))
+              (mu:fix
+               (:lambda (nth)
+                 (:if (core:numberp nth)
+                      (:if (mu:eq nth (mu:sv-len str-1))
+                           :t
+                           (:if (mu:eq (mu:sv-ref str-1 nth) (mu:sv-ref str-2 nth))
+                                (core:1+ nth)
+                                ()))
+                      nth))
+               0)
+              ()))))
 
 ;;;
 ;;; string construction
@@ -55,29 +54,36 @@
 
 (mu:intern core::ns :extern "string-append"
    (:lambda (list)
-      (core:errorp-unless core:listp list "core:string: is not a list")
-      (mu:vector
-       :char
-       (core:foldl
-        (:lambda (elt acc)
-          (core:errorp-unless core:stringp elt "core:string: is not a string")
-          (core::append acc (core:sv-list elt)))
-        ()
-        list))))
+     (core:errorp-unless core:listp list "core:string: is not a list")
+     ((:lambda (result)
+       (core:mapc
+        (:lambda (str)
+          (core:errorp-unless core:stringp str "core:string-append: is not a string")
+          (mu:fix
+           (:lambda (nth)
+             (:if (mu:eq (mu:sv-len str) nth)
+                  nth
+                  (core::prog2
+                      (mu:write (mu:sv-ref str nth) () result)
+                      (core:1+ nth))))
+           0))
+        list)
+       (mu:get-str result))
+     (mu:open :string :output ""))))
 
-(mu:intern core::ns :intern "string-append"
-   (:lambda (str-1 str-2)
-      (core:errorp-unless core:stringp str-1 "is not a string (core::string)")
-      (core:errorp-unless core:stringp str-2 "is not a string (core::string)")
-      (mu:vector :char (core::append (core:sv-list str-1) (core:sv-list str-2)))))
-
-(mu:intern core::ns :extern "substr"
+(mu:intern core::ns :intern "substr"
   (:lambda (str start end)
-     (core:errorp-unless core:stringp str "is not a string (core::substr)")
-     (core:errorp-unless core:fixnump start "is not a fixnum (core::substr)")
-     (core:errorp-unless core:fixnump end "is not a fixnum (core::substr)")
-     ((:lambda (list)
-        (mu:vector
-          :char
-          (core:dropl (core:dropr list (mu:fx-sub (mu:length list) (core:1+ end))) start)))
-      (core:sv-list str))))
+     (core:errorp-unless core:stringp str "core:substr: is not a string")
+     (core:errorp-unless core:fixnump start "core:substr: start is not a fixnum")
+     (core:errorp-unless core:fixnump end "core:substr: end is not a fixnum")
+     ((:lambda (substr)
+        (mu:fix
+         (:lambda (nth)
+           (:if (core:numberp nth)
+                (:if (mu:fx-lt nth end)
+                     (mu:write (mu:sv-ref str nth) () substr)
+                     ())
+                nth))
+         start)
+        (mu:get-str substr))
+        (mu:open :string :output ""))))

--- a/src/mu/types/stream.rs
+++ b/src/mu/types/stream.rs
@@ -501,7 +501,7 @@ impl Core for Stream {
                 let stream_id = Fixnum::as_i64(mu, image.source) as usize;
                 SystemStream::write_byte(system_stream, stream_id, ch as u8)
             }
-            Type::Cons => {
+            Type::Null | Type::Cons => {
                 image.source = Cons::new(Char::as_tag(ch), image.source).evict(mu);
                 image.count = Fixnum::as_tag(Fixnum::as_i64(mu, image.count) + 1);
                 Self::update(mu, &image, stream);

--- a/tests/core/strings
+++ b/tests/core/strings
@@ -1,14 +1,15 @@
 #
-# core string tests"
+# core string tests
 #
 assert_eq "(mu:type-of core:schar)" ":func"
 assert_eq "(mu:type-of core:string=)" ":func"
 assert_eq "(mu:type-of core:string)" ":func"
 assert_eq "(mu:type-of core:string-append)" ":func"
-assert_eq "(mu:type-of core:substr)" ":func"
+assert_eq "(core:string-append '(\"abc\" \"123\"))" '"abc123"'
+assert_eq "(core:string-append '(\"\" \"abc\"))" '"abc"'
+assert_eq "(core:string-append '(\"abc\" \"\"))" '"abc"'
+assert_eq "(core:string-append '(\"\" \"\"))" '""'
 assert_eq "(core:string= \"abc\" \"abc\")" ":t"
 assert_eq "(core:string= \"abd\" \"abc\")" ":nil"
 assert_eq "(core:stringp \"abc\")" ":t"
 assert_eq "(core:stringp 1)" ":nil"
-assert_eq "(core:sv-list \"abc\")" "(a b c)"
-#

--- a/tests/report.py
+++ b/tests/report.py
@@ -22,7 +22,7 @@ for test in test_results:
     if fields[0] in labels:
         totals = fields
     else:
-        form = (fields[0][:27] + '... ') if len(fields[0]) > 30 else fields[0]
+        form = (fields[0][:27] + '...') if len(fields[0]) > 30 else fields[0]
         if len(fields) != 4:
             if len(fields) == 1:
                 pass


### PR DESCRIPTION
Rewrite string-append and substr

Remove sv-list silliness, and intern substr

Docs: no change
Tests: add string-append tests, remove substr test, all string tests pass
Mu: let wr-char write an empty string stream (why isn't this tested for?)
