### PR TITLE
#72 - core: mapv like mapc

### DIFF
--- a/src/core/strings.l
+++ b/src/core/strings.l
@@ -59,19 +59,12 @@
        (core:mapc
         (:lambda (str)
           (core:errorp-unless core:stringp str "core:string-append: is not a string")
-          (mu:fix
-           (:lambda (nth)
-             (:if (mu:eq (mu:sv-len str) nth)
-                  nth
-                  (core::prog2
-                      (mu:write (mu:sv-ref str nth) () result)
-                      (core:1+ nth))))
-           0))
+          (core::mapv (:lambda (item) (mu:write item () result)) str))
         list)
        (mu:get-str result))
      (mu:open :string :output ""))))
 
-(mu:intern core::ns :intern "substr"
+(mu:intern core::ns :extern "substr"
   (:lambda (str start end)
      (core:errorp-unless core:stringp str "core:substr: is not a string")
      (core:errorp-unless core:fixnump start "core:substr: start is not a fixnum")
@@ -80,9 +73,13 @@
         (mu:fix
          (:lambda (nth)
            (:if (core:numberp nth)
-                (:if (mu:fx-lt nth end)
-                     (mu:write (mu:sv-ref str nth) () substr)
-                     ())
+                (:if (mu:eq nth (mu:sv-len str))
+                     ()
+                     (:if (mu:fx-lt nth (core:1+ end))
+                          (core::prog2
+                              (mu:write (mu:sv-ref str nth) () substr)
+                              (core:1+ nth))
+                          ()))
                 nth))
          start)
         (mu:get-str substr))

--- a/src/core/vectors.l
+++ b/src/core/vectors.l
@@ -5,12 +5,30 @@
 ;;;  core vectors
 ;;;
 (mu:intern core::ns :extern "vector-type"
-   (:lambda (vector)
-     (core:errorp-unless core:vectorp vector "core:vector-type: not a vector")
-     (mu:sv-type vector)))
+  (:lambda (vector)
+    (core:errorp-unless core:vectorp vector "core:vector-type: not a vector")
+
+    (mu:sv-type vector)))
 
 (mu:intern core::ns :extern "svref"
-   (:lambda (vector nth)
-     (core:errorp-unless core:vectorp vector "core:svref: not a vector")
-     (core:errorp-unless core:fixnump nth "core:svref: not a fixnum")
-     (mu:sv-ref vector nth)))
+  (:lambda (vector nth)
+    (core:errorp-unless core:vectorp vector "core:svref: not a vector")
+    (core:errorp-unless core:fixnump nth "core:svref: not a fixnum")
+
+    (mu:sv-ref vector nth)))
+
+(mu:intern core::ns :intern "mapv"
+  (:lambda (fn vector)
+    (core:errorp-unless core:functionp fn "core::mapv: not a function")
+    (core:errorp-unless core:vectorp vector "core::mapv: not a vector")
+
+    (mu:fix
+     (:lambda (nth)
+       (:if nth
+            (:if (mu:eq nth (mu:sv-len vector))
+                 ()
+                 (core::prog2
+                     (mu:apply fn (core::list (mu:sv-ref vector nth)))
+                     (core:1+ nth)))
+            ()))
+     0)))

--- a/src/mu/core/classes.rs
+++ b/src/mu/core/classes.rs
@@ -24,7 +24,7 @@ pub enum Tag {
 }
 
 // classes
-#[derive(Eq, PartialEq, Copy, Clone, Debug, TryFromPrimitive)]
+#[derive(PartialEq, Copy, Clone, Debug, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Type {
     Byte,
@@ -65,7 +65,7 @@ pub struct TagU64 {
     pub offset: B61,
 }
 
-#[derive(BitfieldSpecifier, Copy, Clone)]
+#[derive(BitfieldSpecifier, Copy, Clone, Eq, PartialEq)]
 pub enum DirectType {
     Char = 0,
     Byte = 1,

--- a/tests/core/strings
+++ b/tests/core/strings
@@ -5,6 +5,7 @@ assert_eq "(mu:type-of core:schar)" ":func"
 assert_eq "(mu:type-of core:string=)" ":func"
 assert_eq "(mu:type-of core:string)" ":func"
 assert_eq "(mu:type-of core:string-append)" ":func"
+assert_eq "(mu:type-of core:substr)" ":func"
 assert_eq "(core:string-append '(\"abc\" \"123\"))" '"abc123"'
 assert_eq "(core:string-append '(\"\" \"abc\"))" '"abc"'
 assert_eq "(core:string-append '(\"abc\" \"\"))" '"abc"'
@@ -13,3 +14,6 @@ assert_eq "(core:string= \"abc\" \"abc\")" ":t"
 assert_eq "(core:string= \"abd\" \"abc\")" ":nil"
 assert_eq "(core:stringp \"abc\")" ":t"
 assert_eq "(core:stringp 1)" ":nil"
+assert_eq '(core:substr "abc" 0 0)' '"a"'
+assert_eq '(core:substr "abc" 0 1)' '"ab"'
+assert_eq '(core:substr "abc" 1 3)' '"bc"'


### PR DESCRIPTION
Add core::mapv and core:substr

Gateway to sequences

Doc: no change
Tests: add substr tests
Mu: no change
Core: add core::mapv, and core:substr