### PR TITLE
#79 - commit test summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "    uninstall - uninstall distribution (needs sudo)"
 	@echo "--- development options"
 	@echo "    clean - remove build artifacts"
-	@echo "    commit - run clippy and rustfmt"
+	@echo "    commit - run clippy, rustfmt, make test summary"
 	@echo "    tags - make etags"
 	@echo "--- commit test options"
 	@echo "    tests/rust - rust tests"
@@ -62,6 +62,7 @@ commit:
 	@cargo -q test | sed -e '/^$$/d'
 	@echo ";;; clippy tests"
 	@cargo clippy
+	@make -C tests commit
 
 clean:
 	@rm -f TAGS

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ and then install.
 
 ------
 
-The distribution includes a test suite, which should be run after every interesting change and prior to any check in. The test suite consists of a several hundred individual tests separated into multiple sections, roughly separated by namespace.
+*Performance metrics are not yet implemented.*
 
-Performance metrics are not yet implemented.
+The distribution includes a test suite, which should be run after every interesting change. The test suite consists of a several hundred individual tests separated into multiple sections, roughly separated by namespace.
 
 Failures in the *mu* tests are almost guaranteed to cause complete failure of subsequent tests.
 
@@ -139,7 +139,7 @@ The `tests` makefile has additional facilities for development, including report
 
 ------
 
-Performance metrics, which can take in excess of ten minutes to run, can be captured with
+Performance metrics can be captured with
 
 ```
 % make -C perf base
@@ -228,7 +228,9 @@ to your `~/.inputrc` may help.
 
 *dyad* is named for the dual core semantics of LISP expressions, *eval* and *apply*. Functional languages bring us closer to a time where we can prove our programs are correct. *dyad* attempts to couch modern programming concepts in a familiar language.
 
-*LISP* is a path, one of many. *LISPs* are intentionally dynamic which has selected against them for use in production environments, yet statically-typed languages produce systems that are hard to interact with and even harder to change *in situ*.
+*LISPs* are intentionally dynamic which has selected against them for use in production environments, yet statically-typed languages produce systems that are hard to interact with and even harder to change *in situ*. Many of the dynamic languages in use today do not have adequate meta programming facilities. We need systems that can reason about and suplement themselves.
+
+Such systems tend to be large and resource-hungry. We need lean systems that can do useful work in a low resource environment and evolve to meet new demands.
 
 Change and evolution are the only defenses a system has against obsolescence.
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 #
 # tests makefile
 #
-.PHONY: help cargo clean report report-all summary mu core results
+.PHONY: help cargo clean commit report report-all summary mu core results
 
 TMPF:=$(shell mktemp)
 NAMESPACES=\
@@ -14,6 +14,7 @@ help:
 	@echo "--- test options"
 	@echo "    cargo - run rust tests"
 	@echo "    namespaces - list namespaces"
+	@echo "    commit - create test summary"
 	@echo "    list - tests in \$$NAMESPACE"
 	@echo "    \$$NAMESPACE - run all tests in namespace, raw output"
 	@echo "    summary - run all tests in all namespaces and print summary"
@@ -55,6 +56,13 @@ report-all:
 report:
 	@bash $(NAMESPACE)/run-test $(NAMESPACE)/$(TEST) > $(TMPF)
 	@python3 report.py $(TMPF)
+	@rm -f $(TMPF)
+
+commit:
+	@for namespace in $(NAMESPACES); do	\
+	    make $$namespace >> $(TMPF);	\
+	done
+	@python3 summary.py $(TMPF) > tests.summary
 	@rm -f $(TMPF)
 
 summary:

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,0 +1,32 @@
+Test Summary: 02/13/2023 09:35:53
+------------------------
+mu:      chars                    total:  2       failed:  0       aborted:  0      
+mu:      compile                  total:  7       failed:  0       aborted:  0      
+mu:      core                     total:  32      failed:  0       aborted:  0      
+mu:      lists                    total:  22      failed:  0       aborted:  0      
+mu:      namespace                total:  13      failed:  0       aborted:  0      
+mu:      numbers                  total:  34      failed:  0       aborted:  0      
+mu:      reader                   total:  48      failed:  0       aborted:  0      
+mu:      special-forms            total:  11      failed:  0       aborted:  0      
+mu:      streams                  total:  9       failed:  0       aborted:  0      
+mu:      symbols                  total:  10      failed:  0       aborted:  0      
+mu:      vectors                  total:  22      failed:  0       aborted:  0      
+------------------------
+mu:   total 210        failures 0         aborted 0         
+
+core:    compile                  total:  33      failed:  4       aborted:  16     
+core:    core                     total:  26      failed:  0       aborted:  0      
+core:    exceptions               total:  11      failed:  0       aborted:  0      
+core:    format                   total:  16      failed:  0       aborted:  0      
+core:    functions                total:  18      failed:  1       aborted:  6      
+core:    lambda                   total:  44      failed:  21      aborted:  3      
+core:    lists                    total:  52      failed:  0       aborted:  1      
+core:    macro                    total:  14      failed:  1       aborted:  2      
+core:    read                     total:  12      failed:  7       aborted:  0      
+core:    sequences                total:  31      failed:  12      aborted:  0      
+core:    streams                  total:  26      failed:  0       aborted:  0      
+core:    strings                  total:  19      failed:  0       aborted:  0      
+core:    vectors                  total:  10      failed:  0       aborted:  0      
+------------------------
+core: total 312        failures 46        aborted 28        
+


### PR DESCRIPTION
Generate a test summary as part of the commit process

Docs: add verbiage to README
Tests: add commit target to makefile, check in summary

