### PR TITLE
#98 - core: fix position usage

### DIFF
--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -158,7 +158,3 @@
 (mu:intern core::ns :extern "compile"
    (:lambda (form)
      (core::compile form ())))
-          ((:lambda (nthcdr)
-             (:if (core:null nthcdr)
-                  ()
-                  (mu:fx-sub (mu:length list) (mu:length nthcdr))))

--- a/src/core/format.l
+++ b/src/core/format.l
@@ -74,7 +74,7 @@
   (:lambda (dir dest args)
     ((:lambda (fn)
        (:if fn
-            (core:apply (mu:sy-val fn) (core::list2 dest args))
+            (mu:apply (mu:sy-val fn) (core::list2 dest args))
             (core:error dir "core:format: unrecognized format directive")))
      (core::fmt-op-table dir))))
 

--- a/src/core/lambda.l
+++ b/src/core/lambda.l
@@ -207,6 +207,6 @@
                 (:if offset
                      (mu:cons (core::lambda-frame-id frame) offset)
                      ()))
-              (core:positionl mu:eq symbol (core::lambda-syms frame)))))
+              (core:positionl (:lambda (el) (mu:eq el symbol)) (core::lambda-syms frame)))))
       ()
       env)))

--- a/src/core/symbol-macro.l
+++ b/src/core/symbol-macro.l
@@ -32,26 +32,15 @@
 
 (mu:intern core::ns :intern "read-symbol-externp"
    (:lambda (name)
-      (mu:eq (core:positionl mu:eq #\: name) (core:positionr mu:eq #\: name))))
+     ()))
 
 (mu:intern core::ns :intern "read-symbol-ns"
    (:lambda (name)
-      ((:lambda (colon)
-          (:if (core:null colon)
-               ()
-               (core:substr name 0 (core:1- colon))))
-       (core:positionl mu:eq #\: name))))
+     ()))
 
 (mu:intern core::ns :intern "read-symbol-name"
    (:lambda (name)
-      ((:lambda (colon)
-          (:if (core:null colon)
-               name
-               (core:substr
-                 name
-                 (core:1+ colon)
-                 (core:1- (mu:sv-len name)))))
-       (core:positionr mu:eq #\: name))))
+     ()))
 
 (mu:intern core::ns :intern "read-resolve-symbol"
    (:lambda (symbol)

--- a/tests/summary.py
+++ b/tests/summary.py
@@ -19,16 +19,16 @@ for label in labels:
     for test in test_results:
         fields=test[:-1].split(',')
         if fields[0] == label:
-            print(f'{fields[0]:<8} {fields[1]:<14} total: {fields[2]:<8} failed: {fields[3]:<8} aborted: {fields[4]:<8}')
+            print(f'{fields[0]:<10} {fields[1]:<14} total: {fields[2]:<8} failed: {fields[3]:<8} aborted: {fields[4]:<8}')
             test_total += int(fields[2])
             test_fails += int(fields[3])
             test_aborts += int(fields[4])
 
     test_passes = test_total - (test_fails + test_aborts)
     print('-----------------------')
-    print(f'{label:<6}', end='')
-    print(f'total: {test_total:<11}', end='')
-    print(f'passed: {test_passes:<8}', end='')
+    print(f'{label:<11}', end='')
+    print(f'passed: {test_passes:<7}', end='')
+    print(f'total: {test_total:<9}', end='')
     print(f'failed: {test_fails:<9}', end='')
     print(f'aborted: {test_aborts:<10}')
     print()

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,33 +1,33 @@
-Test Summary: 02/16/2023 12:28:13
+Test Summary: 02/16/2023 13:32:35
 -----------------------
-mu:      chars          total: 2        failed: 0        aborted: 0       
-mu:      compile        total: 7        failed: 0        aborted: 0       
-mu:      core           total: 33       failed: 0        aborted: 0       
-mu:      lists          total: 22       failed: 0        aborted: 0       
-mu:      namespace      total: 14       failed: 0        aborted: 0       
-mu:      numbers        total: 34       failed: 0        aborted: 0       
-mu:      reader         total: 46       failed: 0        aborted: 0       
-mu:      special-forms  total: 11       failed: 0        aborted: 0       
-mu:      streams        total: 10       failed: 0        aborted: 0       
-mu:      structs        total: 7        failed: 0        aborted: 0       
-mu:      symbols        total: 10       failed: 0        aborted: 0       
-mu:      vectors        total: 23       failed: 0        aborted: 0       
+mu:        chars          total: 2        failed: 0        aborted: 0       
+mu:        compile        total: 7        failed: 0        aborted: 0       
+mu:        core           total: 33       failed: 0        aborted: 0       
+mu:        lists          total: 22       failed: 0        aborted: 0       
+mu:        namespace      total: 14       failed: 0        aborted: 0       
+mu:        numbers        total: 34       failed: 0        aborted: 0       
+mu:        reader         total: 46       failed: 0        aborted: 0       
+mu:        special-forms  total: 11       failed: 0        aborted: 0       
+mu:        streams        total: 10       failed: 0        aborted: 0       
+mu:        structs        total: 7        failed: 0        aborted: 0       
+mu:        symbols        total: 10       failed: 0        aborted: 0       
+mu:        vectors        total: 23       failed: 0        aborted: 0       
 -----------------------
-mu:   total: 219        passed: 219     failed: 0        aborted: 0         
+mu:        passed: 219    total: 219      failed: 0        aborted: 0         
 
-core:    closures       total: 14       failed: 7        aborted: 6       
-core:    compile        total: 29       failed: 6        aborted: 16      
-core:    core           total: 22       failed: 0        aborted: 0       
-core:    exceptions     total: 7        failed: 0        aborted: 0       
-core:    format         total: 12       failed: 8        aborted: 0       
-core:    lambda         total: 42       failed: 24       aborted: 3       
-core:    lists          total: 76       failed: 0        aborted: 1       
-core:    macro          total: 9        failed: 1        aborted: 2       
-core:    read           total: 9        failed: 7        aborted: 0       
-core:    sequences      total: 3        failed: 0        aborted: 0       
-core:    streams        total: 23       failed: 0        aborted: 0       
-core:    strings        total: 16       failed: 0        aborted: 0       
-core:    vectors        total: 13       failed: 0        aborted: 0       
+core:      closures       total: 14       failed: 7        aborted: 6       
+core:      compile        total: 29       failed: 6        aborted: 16      
+core:      core           total: 22       failed: 0        aborted: 0       
+core:      exceptions     total: 7        failed: 0        aborted: 0       
+core:      format         total: 12       failed: 0        aborted: 0       
+core:      lambda         total: 42       failed: 24       aborted: 3       
+core:      lists          total: 76       failed: 0        aborted: 1       
+core:      macro          total: 9        failed: 1        aborted: 2       
+core:      read           total: 9        failed: 7        aborted: 0       
+core:      sequences      total: 3        failed: 0        aborted: 0       
+core:      streams        total: 23       failed: 0        aborted: 0       
+core:      strings        total: 16       failed: 0        aborted: 0       
+core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core: total: 275        passed: 194     failed: 53       aborted: 28        
+core:      passed: 202    total: 275      failed: 45       aborted: 28        
 


### PR DESCRIPTION
Use positions consistently, change some core::apply to mu:apply until we get that right

Doc: no change
Tests: fiddle with report formatting, more tests now pass
Core: replace core::apply with mu:apply in format.l and symbol-macro.l, fix trailing garbage in compile.l, positions in lambda.l