### PR TITLE
#109 - mu: add compiler trait

### DIFF
--- a/src/mu/core/classes.rs
+++ b/src/mu/core/classes.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu classes

--- a/src/mu/core/exception.rs
+++ b/src/mu/core/exception.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu exceptions:

--- a/src/mu/core/frame.rs
+++ b/src/mu/core/frame.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! function call frame

--- a/src/mu/core/functions.rs
+++ b/src/mu/core/functions.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu functions

--- a/src/mu/core/image.rs
+++ b/src/mu/core/image.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu image

--- a/src/mu/core/mod.rs
+++ b/src/mu/core/mod.rs
@@ -1,9 +1,8 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! core module
 pub mod classes; // needs to be public for API
-mod coerce;
 mod compile;
 pub mod exception; // needs to be public for API
 pub mod frame; // needs to be public for mu native functions

--- a/src/mu/core/mu.rs
+++ b/src/mu/core/mu.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu environment
@@ -8,11 +8,12 @@ use {
     crate::{
         core::{
             classes::{Tag, Type},
-            compile, exception,
+            compile::Compiler,
+            exception,
             exception::{Condition, Exception},
             frame::Frame,
             namespace::Core as _,
-            read::Read,
+            read::Reader,
         },
         image::heap::Heap,
         system::sys as system,
@@ -211,7 +212,7 @@ impl Core for Mu {
     }
 
     fn compile(&self, tag: Tag) -> exception::Result<Tag> {
-        compile::compile(self, tag)
+        <Mu as Compiler>::compile(self, tag)
     }
 
     fn eof(&self, stream: Tag) -> bool {
@@ -219,12 +220,12 @@ impl Core for Mu {
     }
 
     fn read(&self, stream: Tag, eofp: bool, eof_value: Tag) -> exception::Result<Tag> {
-        <Mu as Read>::read(self, stream, eofp, eof_value, false)
+        <Mu as Reader>::read(self, stream, eofp, eof_value, false)
     }
 
     fn read_string(&self, string: String) -> exception::Result<Tag> {
         match Stream::open_string(self, &string, true) {
-            Ok(stream) => <Mu as Read>::read(self, stream, true, Tag::nil(), false),
+            Ok(stream) => <Mu as Reader>::read(self, stream, true, Tag::nil(), false),
             Err(e) => Err(e),
         }
     }

--- a/src/mu/core/namespace.rs
+++ b/src/mu/core/namespace.rs
@@ -1,11 +1,10 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu namespace symbols
 use crate::{
     core::{
         classes::{MuFunction as _, Tag},
-        coerce::MuFunction as _,
         exception::{Exception, MuFunction as _},
         frame::{Frame, MuFunction as _},
         functions::MuFunction as _,
@@ -13,6 +12,7 @@ use crate::{
         mu::{Mu, MuFunctionType},
     },
     types::{
+        coerce::MuFunction as _,
         cons::{Cons, MuFunction as _},
         fixnum::{Fixnum, MuFunction as _},
         float::{Float, MuFunction as _},

--- a/src/mu/core/read.rs
+++ b/src/mu/core/read.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu reader
@@ -36,7 +36,7 @@ lazy_static! {
 //     errors propagate out of read()
 //
 
-pub trait Read {
+pub trait Reader {
     fn read(_: &Mu, _: Tag, _: bool, _: Tag, _: bool) -> exception::Result<Tag>;
     fn read_atom(_: &Mu, _: char, _: Tag) -> exception::Result<Tag>;
     fn read_block_comment(_: &Mu, _: Tag) -> exception::Result<Option<()>>;
@@ -47,7 +47,7 @@ pub trait Read {
     fn read_token(_: &Mu, _: Tag) -> exception::Result<Option<String>>;
 }
 
-impl Read for Mu {
+impl Reader for Mu {
     //
     // read whitespace:
     //

--- a/src/mu/core/readtable.rs
+++ b/src/mu/core/readtable.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu reader readtable

--- a/src/mu/image/heap.rs
+++ b/src/mu/image/heap.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu heap

--- a/src/mu/image/mod.rs
+++ b/src/mu/image/mod.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu heap module

--- a/src/mu/lib.rs
+++ b/src/mu/lib.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! libmu library

--- a/src/mu/system/mod.rs
+++ b/src/mu/system/mod.rs
@@ -1,5 +1,5 @@
 //
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! system module

--- a/src/mu/system/stream.rs
+++ b/src/mu/system/stream.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! system streams

--- a/src/mu/system/sys.rs
+++ b/src/mu/system/sys.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! system interface

--- a/src/mu/types/char.rs
+++ b/src/mu/types/char.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu character class

--- a/src/mu/types/coerce.rs
+++ b/src/mu/types/coerce.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu coercion

--- a/src/mu/types/cons.rs
+++ b/src/mu/types/cons.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu cons class
@@ -11,7 +11,7 @@ use {
             exception::{Condition, Exception},
             frame::Frame,
             mu::{Core as _, Mu},
-            read::{Read, EOL},
+            read::{Reader, EOL},
         },
         image,
         types::{
@@ -114,17 +114,18 @@ impl Core for Cons {
     fn read(mu: &Mu, stream: Tag) -> exception::Result<Tag> {
         let dot = Tag::to_direct('.' as u64, 1, DirectType::Byte);
 
-        match <Mu as Read>::read(mu, stream, false, Tag::nil(), true) {
+        match <Mu as Reader>::read(mu, stream, false, Tag::nil(), true) {
             Ok(car) => {
                 if EOL.eq_(car) {
                     Ok(Tag::nil())
                 } else {
                     match Tag::type_of(mu, car) {
                         Type::Symbol if dot.eq_(Symbol::name_of(mu, car)) => {
-                            match <Mu as Read>::read(mu, stream, false, Tag::nil(), true) {
+                            match <Mu as Reader>::read(mu, stream, false, Tag::nil(), true) {
                                 Ok(cdr) if EOL.eq_(cdr) => Ok(Tag::nil()),
                                 Ok(cdr) => {
-                                    match <Mu as Read>::read(mu, stream, false, Tag::nil(), true) {
+                                    match <Mu as Reader>::read(mu, stream, false, Tag::nil(), true)
+                                    {
                                         Ok(eol) if EOL.eq_(eol) => Ok(cdr),
                                         Ok(_) => Err(Exception::raise(
                                             mu,

--- a/src/mu/types/fixnum.rs
+++ b/src/mu/types/fixnum.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu fixnum type

--- a/src/mu/types/float.rs
+++ b/src/mu/types/float.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu float type

--- a/src/mu/types/function.rs
+++ b/src/mu/types/function.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu function type

--- a/src/mu/types/ivector.rs
+++ b/src/mu/types/ivector.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu image vector type

--- a/src/mu/types/mod.rs
+++ b/src/mu/types/mod.rs
@@ -1,8 +1,9 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu types module
 pub mod char;
+pub mod coerce;
 pub mod cons;
 pub mod fixnum;
 pub mod float;

--- a/src/mu/types/namespace.rs
+++ b/src/mu/types/namespace.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu namespace type

--- a/src/mu/types/stream.rs
+++ b/src/mu/types/stream.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu stream type

--- a/src/mu/types/struct.rs
+++ b/src/mu/types/struct.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu struct type

--- a/src/mu/types/vector.rs
+++ b/src/mu/types/vector.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! mu vector type

--- a/src/runtime/main.rs
+++ b/src/runtime/main.rs
@@ -1,4 +1,4 @@
-//  SPDX-FileCopyrightText: Copyright 2022-2023 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
 //! runtime loader/repl

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,4 +1,4 @@
-Test Summary: 02/20/2023 16:13:42
+Test Summary: 02/21/2023 11:44:42
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
 mu:        compile        total: 7        failed: 0        aborted: 0       


### PR DESCRIPTION
Reduce global namespace and use canonical copyright year

Docs: no change
Tests: no change
Mu: add compiler trait to core, adjust copyright boilerplate