### PR TITLE
#82 - mu: review lexical resolution

### DIFF
--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -137,7 +137,6 @@
 
 (mu:intern core::ns :intern "compile"
     (:lambda (form env)
-      (core:warn form "core::compile")
       (core:errorp-unless core:listp env "compile: env not a list")
       (:if (core:consp form)
           ((:lambda (fn args)

--- a/src/mu/core/compile.rs
+++ b/src/mu/core/compile.rs
@@ -228,7 +228,7 @@ impl Compiler for Mu {
             Err(e) => return Err(e),
         };
 
-        match Self::compile_list(mu, body) {
+        let form = match Self::compile_list(mu, body) {
             Ok(form) => Ok(Function::new(
                 lambda,
                 Fixnum::as_tag(Cons::length(mu, lambda) as i64),
@@ -237,7 +237,12 @@ impl Compiler for Mu {
             )
             .evict(mu)),
             Err(e) => Err(e),
-        }
+        };
+
+        let mut lexenv_ref: RefMut<Vec<(Tag, Vec<Tag>)>> = mu.compile.borrow_mut();
+        lexenv_ref.pop();
+
+        form
     }
 
     fn compile(mu: &Mu, expr: Tag) -> exception::Result<Tag> {

--- a/tests/core/compile
+++ b/tests/core/compile
@@ -1,10 +1,6 @@
 #
 # general core compiler tests
 #
-assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda () 1))))" ":t"
-assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda (a b) b))))" ":t"
-assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda (a) "hoo"))))" ":t"
-assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda (a) a))))" ":t"
 assert_eq "(mu:eq :func (mu:type-of core::compile-add-env))" ":t"
 assert_eq "(mu:eq :func (mu:type-of core::compile-lambda))" ":t"
 assert_eq "(mu:eq :func (mu:type-of core::compile-lambda-body))" ":t"
@@ -12,7 +8,11 @@ assert_eq "(mu:eq :func (mu:type-of core::compile-symbol))" ":t"
 assert_eq "(mu:eq :func (mu:type-of core::core-lambda))" ":t"
 assert_eq "(mu:eq :func (mu:type-of core::symbol-frame))" ":t"
 assert_eq "(mu:eq :func (mu:type-of core:compile))" ":t"
-# special forms if, defconst
+# special forms if, defconst, lambda
+assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda () 1))))" ":t"
+assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda (a b) b))))" ":t"
+assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda (a) "hoo"))))" ":t"
+assert_eq "(mu:eq :func (mu:type-of (core:compile '(lambda (a) a))))" ":t"
 assert_eq "(core:compile '(defconst foo ()))" "(:quote foo)"
 assert_eq "(mu:apply (core:compile '(lambda () (defconst core:foo 'foo) core:foo)) ())" "foo"
 assert_eq "(mu:eval (core:compile '(if :t :t ())))" ":t"
@@ -31,3 +31,4 @@ assert_eq "(mu:eval (core:compile '(if (core:null ()) (mu:fx-add 0 1) (mu:fx-add
 assert_eq "(mu:eval (core:compile '(if (core:not (core:null :t)) (mu:fx-add 0 1) (mu:fx-add 0 0))))" "1"
 assert_eq "(mu:eval (core:compile '(if (core:null ()) (mu:fx-add 0 1) (core:write \"should not eval\" () ()))))" "1"
 assert_eq "(mu:eval (core:compile '(if (core:null :t) (core:write \"should not eval\" () ()) (mu:fx-add 0 0))))" "0"
+assert_eq "(mu:eval (core:compile '((:lambda (fn) (core:apply (:lambda (fn) (mu:eq :func (mu:type-of fn))) (core::list fn))) mu:eq)))" ":t"

--- a/tests/mu/compile
+++ b/tests/mu/compile
@@ -1,7 +1,8 @@
+assert_eq "((:lambda (fn)(mu:apply (:lambda (fn) (mu:eq :func (mu:type-of fn))) (mu:cons fn ()))) mu:eq)" ":t"
+assert_eq "(mu:apply (mu:compile '(:lambda (a) ((:lambda (a) (mu:fx-add a a)) (mu:fx-add a 2)))) '(1))" "6"
+assert_eq "(mu:apply (mu:compile '(:lambda (a) ((:lambda (b) (mu:fx-add a b)) (mu:fx-add a 2)))) '(1))" "4"
+assert_eq "(mu:apply (mu:compile '(:lambda (a) (mu:fx-add a a))) '(1))" "2"
 assert_eq "(mu:compile #\a)" "#\a"
 assert_eq "(mu:compile 1)" "1"
 assert_eq "(mu:compile :compile)" ":compile"
 assert_eq '(mu:compile "compile")' '"compile"'
-assert_eq "(mu:apply (mu:compile '(:lambda (a) (mu:fx-add a a))) '(1))" "2"
-assert_eq "(mu:apply (mu:compile '(:lambda (a) ((:lambda (b) (mu:fx-add a b)) (mu:fx-add a 2)))) '(1))" "4"
-assert_eq "(mu:apply (mu:compile '(:lambda (a) ((:lambda (a) (mu:fx-add a a)) (mu:fx-add a 2)))) '(1))" "6"

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,7 +1,7 @@
-Test Summary: 02/21/2023 11:44:42
+Test Summary: 02/21/2023 15:53:50
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
-mu:        compile        total: 7        failed: 0        aborted: 0       
+mu:        compile        total: 8        failed: 0        aborted: 0       
 mu:        core           total: 33       failed: 0        aborted: 0       
 mu:        lists          total: 22       failed: 0        aborted: 0       
 mu:        namespace      total: 14       failed: 0        aborted: 0       
@@ -13,10 +13,10 @@ mu:        structs        total: 7        failed: 0        aborted: 0
 mu:        symbols        total: 10       failed: 0        aborted: 0       
 mu:        vectors        total: 23       failed: 0        aborted: 0       
 -----------------------
-mu:        passed: 219    total: 219      failed: 0        aborted: 0         
+mu:        passed: 220    total: 220      failed: 0        aborted: 0         
 
 core:      closures       total: 14       failed: 13       aborted: 0       
-core:      compile        total: 29       failed: 5        aborted: 16      
+core:      compile        total: 30       failed: 22       aborted: 0       
 core:      core           total: 22       failed: 0        aborted: 0       
 core:      exceptions     total: 7        failed: 0        aborted: 0       
 core:      format         total: 12       failed: 0        aborted: 0       
@@ -29,5 +29,5 @@ core:      streams        total: 23       failed: 0        aborted: 0
 core:      strings        total: 16       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 201    total: 268      failed: 50       aborted: 17        
+core:      passed: 201    total: 269      failed: 67       aborted: 1         
 


### PR DESCRIPTION
Fix lexical scoping problem in mu/core/compile.rs

We weren't popping the lexical stack after compiling a lambda form. This led to an outer reference to an inner lexical, which was no longer in scope when accessed. This should eliminate unmapped lexical reference panics.

Docs: no change
Tests: add test cases for the above situation to both core and mu tests
Mu: fix mu lambda compiler
Core: remove debugging