### PR TITLE
#112 - core: compile function applications correctly

### DIFF
--- a/src/core/closures.l
+++ b/src/core/closures.l
@@ -1,4 +1,4 @@
-;;;  SPDX-FileCopyrightText: Copyright 2017-2022 James M. Putnam (putnamjm.design@gmail.com)
+;;;  SPDX-FileCopyrightText: Copyright 2017 James M. Putnam (putnamjm.design@gmail.com)
 ;;;  SPDX-License-Identifier: MIT
 
 ;;;
@@ -92,54 +92,52 @@
 (mu:intern core::ns :extern "apply"
    (:lambda (fn args)
      (core:errorp-unless
-      (:lambda (fn-) (core::log-or (core:functionp fn-) (core:closurep fn-)))
+      (:lambda (fn) (core::log-or (core:functionp fn) (core:closurep fn)))
       fn
       "core:apply: not a function or closure")
      (:if (core:functionp fn)
           (mu:apply fn args)
-          ((:lambda (env)
-             (core:errorp-unless core:closurep fn "core:apply: not a function or closure")
-             (core:mapc mu:fr-push env)
-             ((:lambda (mu-fn)
-                (:if (core::closure-prop :rest fn)
-                     (mu:apply mu-fn (core::quoted-lambda-arg-list fn args))
-                     (mu:apply mu-fn args)))
-              (core::closure-prop :func fn))
-             (core:mapc mu:fr-pop env))
-           (core::closure-prop :env fn)))))
+          (core::closure-apply fn args))))
+
+(mu:intern core::ns :intern "closure-apply"
+   (:lambda (fn args)
+     ((:lambda (env)
+        (core:mapc mu:fr-push env)
+        ((:lambda (mu-fn)
+           (:if (core::closure-prop :rest fn)
+                (mu:apply mu-fn (core::quoted-lambda-arg-list fn args))
+                (mu:apply mu-fn args)))
+         (core::closure-prop :func fn))
+        (core:mapc mu:fr-pop env))
+      (core::closure-prop :env fn))))
 
 ;;;
 ;;; compile-application
 ;;;
 ;;; expand macros
 ;;; convert core lambdas to mu forms
+;;; compile function applications
 ;;;
-
-;;; ((lambda ...) ...)
 (mu:intern core::ns :intern "compile-lambda-call"
   (:lambda (form args env)
     ((:lambda (fn)
-       (core:errorp-unless core:functionp fn "compile-lambda-call: lambda is not a function designator")
-       (:if (core::fn-lambda-desc fn)
-            (core::list3 core:apply fn (core::compile-flat-arg-list args env))
+       (:if (core:closurep fn)
+            (core::list3 core::apply-closure fn (core::compile-flat-arg-list args env))
             (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env))))
      (core::compile form env))))
 
-;;; (function ...)
 (mu:intern core::ns :intern "compile-fn-call"
-  (:lambda (fn args env)        ;;; function call
-        (:if (core::fn-lambda-desc fn)
-             (core::list3 core:apply fn (core::compile-flat-arg-list args env))
-             (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env)))))
+  (:lambda (fn args env)
+    (:if (core::closurep fn)
+         (core::list3 core::apply-closure fn (core::compile-flat-arg-list args env))
+         (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env)))))
 
-;;; (macro-symbol ...)
 (mu:intern core::ns :intern "compile-macro-call"
   (:lambda (macro-symbol args env)
     (core::compile
      (core:macroexpand (mu:cons macro-symbol args) env)
      env)))
 
-;;; (symbol ...)
 (mu:intern core::ns :intern "compile-symbol-call"
   (:lambda (symbol args env)
     (:if (core:boundp symbol)
@@ -154,17 +152,17 @@
 ;;; compile function application
 ;;;
 (mu:intern core::ns :intern "compile-application"
-   (:lambda (fn args env)
-     (:if (core:functionp fn)
-             (core::compile-fn-call fn args env)
-             (:if (core:consp fn)
-                  (core::compile-lambda-call fn args env)
-                  (:if (core:symbolp fn)
-                       (:if (core:boundp fn)
-                            ((:lambda (macro-fn)
-                               (:if macro-fn
-                                    (core::compile-macro-call fn args env)
-                                    (core::symbol-call fn args env)))
-                             (core:macro-function fn env))
-                            (core::compile-symbol-call fn args env))
-                       (core:error fn "compile-application: not a function designator"))))))
+  (:lambda (fn args env)
+    (:if (core:functionp fn)
+         (core::compile-fn-call fn args env)
+         (:if (core:consp fn)
+              (core::compile-lambda-call fn args env)
+              (:if (core:symbolp fn)
+                   (:if (core:boundp fn)
+                        ((:lambda (macro-fn)
+                           (:if macro-fn
+                                (core::compile-macro-call fn args env)
+                                (core::symbol-call fn args env)))
+                         (core:macro-function fn env))
+                        (core::compile-symbol-call fn args env))
+                   (core:error fn "compile-application: not a function designator"))))))

--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -101,11 +101,12 @@
       (core::compile
         ((:lambda (thunk if-impl)
             (mu:cons 'core:apply
-              (mu:cons (thunk
-                        (mu:cons if-impl
-                          (mu:cons (core::compile (mu:nth 1 form) env)
-                            (mu:cons (thunk (mu:nth 2 form))
-                              (core::list (thunk (mu:nth 3 form)))))))
+              (mu:cons (mu:apply thunk
+                (core::list
+                 (mu:cons if-impl
+                   (mu:cons (core::compile (mu:nth 1 form) env)
+                     (mu:cons (mu:apply thunk (core::list (mu:nth 2 form)))
+                       (core::list (mu:apply thunk (mu:nth 3 form))))))))
                 '(()))))
          (:lambda (form)
             (core::compile

--- a/src/core/lambda.l
+++ b/src/core/lambda.l
@@ -112,7 +112,6 @@
 ;;;
 (mu:intern core::ns :intern "compile-closure"
   (:lambda (form env)
-    (core:warn env "compile-closure")
     (core:maplist
      (:lambda (form-cons)
        ((:lambda (compiled-form)
@@ -137,10 +136,8 @@
 ;;;
 (mu:intern core::ns :intern "compile-lambda-body"
   (:lambda (lambda-desc body env)
-    (core:warn body "compile-lambda-body")
     (:if body
          ((:lambda (env)
-              (core:warn env "about to compile-closure")
               (core::compile-closure (mu:cons lambda-desc body) env))
             (core::compile-add-env lambda-desc env))
            ())))
@@ -164,7 +161,6 @@
 ;;;
 (mu:intern core::ns :intern "compile-symbol"
    (:lambda (symbol env)
-     (core:warn symbol "compile-symbol")
      ((:lambda (env-ref)
           (:if env-ref
                (core::compile
@@ -192,15 +188,11 @@
 ;;;
 (mu:intern core::ns :intern "symbol-frame"
    (:lambda (symbol env)
-     (core:warn env "symbol-frame")
      (core:foldl
       (:lambda (frame acc)
-        (core:warn frame "symbol-frame/frame")
-        (core:warn (core::lambda-prop :frame frame) "symbol-frame/frame/id")
         (:if acc
              acc
              ((:lambda (offset)
-                (core:warn offset "symbol-frame/frame/offset")
                 (:if offset
                      (mu:cons (core::lambda-prop :func frame) offset)
                      ()))

--- a/src/core/lists.l
+++ b/src/core/lists.l
@@ -44,11 +44,11 @@
       (mu:cdr
        (mu:fix
         (:lambda (arg)
-          ((:lambda (lst acc)
-             (:if lst
+          ((:lambda (list acc)
+             (:if list
                   (mu:cons
-                   (mu:cdr lst)
-                   (core:apply fn (core::list2 (mu:car lst) acc)))
+                   (mu:cdr list)
+                   (core:apply fn (core::list2 (mu:car list) acc)))
                   arg))
            (mu:car arg)
            (mu:cdr arg)))
@@ -92,11 +92,11 @@
       (core:errorp-unless core:functionp fn "core:mapl: not a function")
       (core:errorp-unless core:listp list "core:mapl: not a list")
       (mu:fix
-       (:lambda (lst)
-         (:if lst
+       (:lambda (list)
+         (:if list
               (core::prog2
-                  (core:apply fn (core::list lst))
-                  (mu:cdr lst))
+                  (core:apply fn (core::list list))
+                  (mu:cdr list))
               ()))
        list)
       list))
@@ -108,11 +108,11 @@
      (mu:car
       (mu:fix
        (:lambda (loop)
-         ((:lambda (acc lst)
-            (:if lst
+         ((:lambda (acc list)
+            (:if list
                  (mu:cons
-                  (core::append acc (core::list (core:apply fn (core::list lst))))
-                  (mu:cdr lst))
+                  (core::append acc (core::list (core:apply fn (core::list list))))
+                  (mu:cdr list))
                  loop))
           (mu:car loop)
           (mu:cdr loop)))

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,4 +1,4 @@
-Test Summary: 02/21/2023 15:53:50
+Test Summary: 02/22/2023 11:02:32
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
 mu:        compile        total: 8        failed: 0        aborted: 0       
@@ -16,7 +16,7 @@ mu:        vectors        total: 23       failed: 0        aborted: 0
 mu:        passed: 220    total: 220      failed: 0        aborted: 0         
 
 core:      closures       total: 14       failed: 13       aborted: 0       
-core:      compile        total: 30       failed: 22       aborted: 0       
+core:      compile        total: 30       failed: 20       aborted: 0       
 core:      core           total: 22       failed: 0        aborted: 0       
 core:      exceptions     total: 7        failed: 0        aborted: 0       
 core:      format         total: 12       failed: 0        aborted: 0       
@@ -29,5 +29,5 @@ core:      streams        total: 23       failed: 0        aborted: 0
 core:      strings        total: 16       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 201    total: 269      failed: 67       aborted: 1         
+core:      passed: 203    total: 269      failed: 65       aborted: 1         
 


### PR DESCRIPTION
Last of the old lambda descriptor references go away

Docs: no change
Tests: couple of tests now pass
Mu: no change
Core: rework function application compiler, add intern for applying closures