### PR TITLE
#117 - core: fix core symbol scopes

### DIFF
--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -96,7 +96,7 @@
 (mu:intern core::ns :intern "thunk"
   (:lambda (form env)
     (core::compile
-     (core::list3 'lambda () form)
+     (core::list3 :lambda () form)
      env)))
 
 (mu:intern core::ns :intern "if-body"

--- a/src/core/exceptions.l
+++ b/src/core/exceptions.l
@@ -23,7 +23,7 @@
                 (core::list2
                  (:if (core:symbolp (core::fn-form fn))
                       (core::fn-form fn)
-                      (core::string-append :intern "lambda-" (core:symbol-name (core::fn-frame-id fn))))
+                      (core:string-append :intern "lambda-" (core:symbol-name (core::fn-frame-id fn))))
                  (core:sv-list args))))
        (mu:car frame)
        (mu:cdr frame))))

--- a/src/core/load.l
+++ b/src/core/load.l
@@ -11,7 +11,7 @@
        (core:errorp-unless core:streamp ifs "core:load cannot open input file")
        (:if verbose
             (core::prog2
-                (core:write (core::string-append ";;; loading " source) () ()) 
+                (core:write (core:string-append ";;; loading " source) () ()) 
                 (core:terpri mu:std-out))
             ())
        (mu:fix

--- a/src/core/macro.l
+++ b/src/core/macro.l
@@ -29,9 +29,9 @@
               (mu:intern
                symbol-ns
                :intern
-               (core::string-append (mu:ns-name symbol-ns) ":macrodefs")
-               (mu:make-ns (mu:make-ns (core::string-append (mu:ns-name symbol-ns) ":macro-functions") ()))))))
-      (mu:ns-map (mu:sy-ns symbol) :intern (core::string-append (mu:ns-name (mu:sy-ns symbol)) ":macrodefs"))
+               (core:string-append (mu:ns-name symbol-ns) ":macrodefs")
+               (mu:make-ns (mu:make-ns (core:string-append (mu:ns-name symbol-ns) ":macro-functions") ()))))))
+      (mu:ns-map (mu:sy-ns symbol) :intern (core:string-append (mu:ns-name (mu:sy-ns symbol)) ":macrodefs"))
       (mu:sy-ns symbol)
       (mu:sy-name symbol)
       (mu:sy-ext symbol))))
@@ -43,7 +43,7 @@
         (:if macro-ns
              (mu:ns-map (mu:sy-val macro-ns) symbol-scope symbol-name)
              ()))
-     (mu:ns-map (mu:sy-ns symbol) :intern (core::string-append (mu:ns-name (mu:sy-ns symbol)) ":macrodefs"))
+     (mu:ns-map (mu:sy-ns symbol) :intern (core:string-append (mu:ns-name (mu:sy-ns symbol)) ":macrodefs"))
      (mu:sy-ns symbol)
      (mu:sy-name symbol)
      (mu:sy-ext symbol))))

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,4 +1,4 @@
-Test Summary: 02/22/2023 19:32:46
+Test Summary: 02/22/2023 20:49:23
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
 mu:        compile        total: 8        failed: 0        aborted: 0       
@@ -16,7 +16,7 @@ mu:        vectors        total: 23       failed: 0        aborted: 0
 mu:        passed: 220    total: 220      failed: 0        aborted: 0         
 
 core:      closures       total: 14       failed: 13       aborted: 0       
-core:      compile        total: 30       failed: 10       aborted: 0       
+core:      compile        total: 30       failed: 4        aborted: 0       
 core:      core           total: 22       failed: 0        aborted: 0       
 core:      exceptions     total: 7        failed: 0        aborted: 0       
 core:      format         total: 12       failed: 0        aborted: 0       
@@ -29,5 +29,5 @@ core:      streams        total: 23       failed: 0        aborted: 0
 core:      strings        total: 16       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 213    total: 269      failed: 55       aborted: 1         
+core:      passed: 219    total: 269      failed: 49       aborted: 1         
 


### PR DESCRIPTION
core:string-append is now an extern, make core if compile mu lambda thunks

Docs: no change
Tests: more if tests pass
Mu: no change
Core: change the scope of string-append references and make the if compiler compile a mu lambda thunk
