### PR TITLE
#120 - mu: clean up stream unreads

### DIFF
--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -48,7 +48,7 @@
 
 (mu:intern core::ns :intern "lambda"
     (:lambda (form env)
-      (core:error-if (mu:fx-lt (mu:length form) 2) form "lambda: malformed lambda expression")
+      (core:error-if (mu:fx-lt (mu:length form) 2) form "core lambda: malformed lambda expression")
       (core::compile-lambda (core::list2 (mu:nth 1 form) (mu:nthcdr 2 form)) env)))
 
 (mu:intern core::ns :intern "defconst"

--- a/src/core/read.l
+++ b/src/core/read.l
@@ -10,7 +10,7 @@
 ;;;
 ;;; readtable
 ;;;
-(mu:intern core::ns :extern "read-char-syntax"
+(mu:intern core::ns :intern "read-char-syntax"
    (:lambda (ch)
      ((:lambda (read-table) (mu:cdr (core:assoc ch read-table)))
       '((#\return . :wspace) (#\linefeed . :wspace) (#\page . :wspace)

--- a/src/core/streams.l
+++ b/src/core/streams.l
@@ -82,12 +82,14 @@
       (core::read-stream-designator designator))))
 
 (mu:intern core::ns :extern "unread-char"
-   (:lambda (char designator)
-     (mu:un-byte (mu:coerce char :fixnum) (core::write-stream-designator designator))))
+  (:lambda (char designator)
+    (core:errorp-unless core:charp char "core:unread-char: not a char")
+    (mu:un-char char (core::write-stream-designator designator))))
 
 (mu:intern core::ns :extern "unread-byte"
-   (:lambda (byte designator)
-     (mu:un-byte byte (core::write-stream-designator designator))))
+  (:lambda (byte designator)
+    (core:errorp-unless core:fixnump char "core:unead-byte: not a byte")
+    (mu:un-byte byte (core::write-stream-designator designator))))
 
 ;;;
 ;;; read/write

--- a/src/mu/core/namespace.rs
+++ b/src/mu/core/namespace.rs
@@ -111,6 +111,7 @@ lazy_static! {
         ("rd-byte", Scope::Extern, 3, Stream::mu_read_byte),
         ("rd-char", Scope::Extern, 3, Stream::mu_read_char),
         ("un-char", Scope::Extern, 2, Stream::mu_unread_char),
+        ("un-byte", Scope::Extern, 2, Stream::mu_unread_byte),
         ("wr-byte", Scope::Extern, 2, Stream::mu_write_byte),
         ("wr-char", Scope::Extern, 2, Stream::mu_write_char),
         // interns

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,4 +1,4 @@
-Test Summary: 02/22/2023 20:49:23
+Test Summary: 02/23/2023 12:20:06
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
 mu:        compile        total: 8        failed: 0        aborted: 0       


### PR DESCRIPTION
Add byte unread and adjust callers from core

Docs: no change
Tests: no change
Mu: add byte unread and fix errant eof condition
Core: clean up core stream unread functions