### PR TITLE
#122 - core: review reader implementation

### DIFF
--- a/src/core/closures.l
+++ b/src/core/closures.l
@@ -92,7 +92,7 @@
 (mu:intern core::ns :extern "apply"
    (:lambda (fn args)
      (core:errorp-unless
-      (:lambda (fn) (core::log-or (core:functionp fn) (core:closurep fn)))
+      (:lambda (fn) (core::logor (core:functionp fn) (core:closurep fn)))
       fn
       "core:apply: not a function or closure")
      (:if (core:functionp fn)

--- a/src/core/core.l
+++ b/src/core/core.l
@@ -60,11 +60,11 @@
 ;;;
 ;;; syntactic sugar
 ;;;
-(mu:intern core::ns :intern "log-or"
+(mu:intern core::ns :intern "logor"
   (:lambda (arg arg1)
     (:if arg arg arg1)))
 
-(mu:intern core::ns :intern "log-and"
+(mu:intern core::ns :intern "logand"
   (:lambda (arg arg1)
     (:if arg arg1 ())))
 

--- a/src/core/lists.l
+++ b/src/core/lists.l
@@ -151,7 +151,7 @@
 (mu:intern core::ns :extern "positionl"
    (:lambda (fn list)
      (core:errorp-unless core:functionp fn "core:positionl: not a function")           
-     (core:errorp-unless core:sequencep list "core:positionl: not a list")
+     (core:errorp-unless core:listp list "core:positionl: not a list")
      (:if (core:null list)
           ()
           ((:lambda (len)
@@ -171,7 +171,7 @@
 (mu:intern core::ns :extern "positionr"
    (:lambda (fn list)
      (core:errorp-unless core:functionp fn "core:positionr: not a function")           
-     (core:errorp-unless core:sequencep list "core:positionr: not a list")
+     (core:errorp-unless core:listp list "core:positionr: not a list")
      (:if (core:null list)
           ()
           (mu:car

--- a/src/core/read-macro.l
+++ b/src/core/read-macro.l
@@ -51,7 +51,7 @@
    (:lambda (base stream)
      (mu:fix           
       (:lambda (loop)
-        (:if (core::log-or (mu:eof stream) (core:numberp loop))
+        (:if (core::logor (mu:eof stream) (core:numberp loop))
              loop
              ((:lambda (ch)
                 ((:lambda (syntax-type)
@@ -104,7 +104,7 @@
                         (:if (mu:eq form core::read-list-eol)
                              (mu:fr-setv (core::fn-frame-id self) 1 core::read-list-eol)
                              (:if (core:symbolp form)
-                                  (:if (core::log-and (core:uninternedp form) (mu:eq (mu:sy-name form) "."))
+                                  (:if (core::logand (core:uninternedp form) (mu:eq (mu:sy-name form) "."))
                                        ((:lambda (dotted)
                                           (core:error-if (core:null list) dotted "read-list: malformed dotted list")
                                           ((:lambda (eol)

--- a/src/core/read.l
+++ b/src/core/read.l
@@ -43,43 +43,87 @@
 ;;;
 ;;; number reader
 ;;;
+(mu:intern core::ns :intern "parse-integer"
+  (:lambda (digits base)
+    (:if (core:zerop (core:length digits))
+         ()
+         ((:lambda (sign)
+            (mu:cdr
+             (mu:fix
+              (:lambda (loop)
+                (:if (core:null loop)
+                     ()
+                     ((:lambda (index acc)
+                        (:if (mu:fx-lt (core:1- (core:length digits)) index)
+                             loop
+                             ((:lambda (digit pos)
+                                (:if (core:null pos)
+                                     ()
+                                     (:if (mu:fx-lt base pos)
+                                          ()
+                                          (mu:cons (core:1+ index) (mu:fx-add pos (mu:fx-mul acc base))))))
+                              (core:schar digits index)
+                              (core:string-positionl (:lambda (ch) (mu:eq ch (core:schar digits index))) "0123456789abcdef"))))
+                      (mu:car loop)
+                      (mu:cdr loop))))
+              (:if (core:fixnump sign)
+                   '(1 . 0)
+                   '(0 . 0)))))         
+          ((:lambda (digit)
+             (:if (mu:eq #\- digit)
+                  -1
+                  (:if (mu:eq #\+ digit)
+                       1
+                       ())))
+           (core:schar digits 0))))))
+
+(mu:intern core::ns :intern "parse-float"
+  (:lambda (str)
+    1.0))
+
 (mu:intern core::ns :intern "read-number"
    (:lambda (atom)
      ((:lambda (fx)
         (:if fx
              fx
-             (mu::fparse atom)))
-      (mu::iparse atom 10))))
+             (core::parse-float atom)))
+      (core::parse-integer atom 10))))
 
 ;;;
 ;;; atom reader
 ;;;
 (mu:intern core::ns :intern "read-atom"
-   (:lambda (stream)
-     (core:errorp-when mu:eof stream "core::read-atom: unexpected eof")
+  (:lambda (stream)
+    (core:errorp-when mu:eof stream "core::read-atom: unexpected eof")
+    (mu:car
      (mu:fix
-      (:lambda (self end atom)
-        (:if (core::logi-or (core:fixnump end) (mu:eof stream))
-             atom
-             ((:lambda (ch)
-                (:if (mu:eq :const (core::read-char-syntax ch))
-                     (core::prog2
-                        (core:write-char ch core::reader-stream)
-                        (mu:fr-setv (core::fn-frame-id self) 1 (core:null end)))
-                     ((:lambda ()
-                        (core:unread-char ch stream)
-                        (mu:fr-setv (core::fn-frame-id self) 1 0)
-                        (mu:fr-setv (core::fn-frame-id self) 2
-                                     ((:lambda (value)
-                                        ((:lambda (number)
-                                           (:if number
-                                                number
-                                                (core::symbol-macro-expand (core::read-resolve-symbol value))))
-                                         (core::read-number value)))
-                                      (core:get-output-stream-string core::reader-stream)))
-                        atom))))
-              (core:read-char stream () ()))))
-      '(() ()))))
+      (:lambda (loop)
+        (:if (core:consp loop)
+             loop
+             (:if (mu:eof stream)
+                  ((:lambda (token)
+                     ((:lambda (number)
+                        (:if number
+                             (core::list number)
+                             (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
+                      (core::read-number token)))
+                   (core:get-output-stream-string core::reader-stream))
+                  ((:lambda (ch)
+                     (:if (mu:eq :const (core::read-char-syntax ch))
+                          ((:lambda ()
+                             (core:write-char ch core::reader-stream)
+                             (core:null loop)))
+                          (core::prog2
+                              (core:unread-char ch stream)
+                              ((:lambda (token)
+                                 ((:lambda (number)
+                                    (:if number
+                                         (core::list number)
+                                         (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
+                                  (core::read-number token)))
+                               (core:get-output-stream-string core::reader-stream)))))
+                   (core:read-char stream () ())))))
+      ()))))
 
 ;;;
 ;;; parser
@@ -91,11 +135,11 @@
         (mu:apply
          (mu:sy-val (mu:cdr (core:assoc (core::read-char-syntax ch) dispatch-table)))
          (core::list stream)))
-      '((:const . core::read-atom)
-        (:macro       . core::read-macro)
-        (:tmacro      . core::read-macro)
-        (:escape      . core::read-atom)
-        (:mescape     . core::read-atom)))))
+      '((:const   . core::read-atom)
+        (:macro   . core::read-macro)
+        (:tmacro  . core::read-macro)
+        (:escape  . core::read-atom)
+        (:mescape . core::read-atom)))))
 
 ;;;
 ;;; core reader
@@ -104,7 +148,7 @@
    (:lambda (stream)
      (mu:fix
       (:lambda (loop)
-        (:if (core::log-or (core:streamp loop) (core:charp loop))
+        (:if (core::logor (core:streamp loop) (core:charp loop))
              loop
              ((:lambda (ch)
                 (:if (mu:eof stream)
@@ -129,45 +173,18 @@
               (core:read-char stream () ()))))
       ())))
 
-
-
+;;;
+;;; recursive reader
+;;;
 (mu:intern core::ns :intern "read"
-   (:lambda (stream)
-     (core:errorp-unless core:streamp stream ":read: not a stream")
-     ((:lambda (read-consume-ws)
-        ((:lambda (ch)
-           (:if (mu:eof stream)
-                ()
-                ((:lambda (macro)
-                   (:if macro
-                        (core:apply (mu:car macro) (core::list2 stream ch))
-                        (core::read-dispatch ch stream)))
-                 (core:get-macro-character ch))))
-         (mu:apply read-consume-ws ())))
-      (:lambda ()
-        (mu:fix
-         (:lambda (loop)
-           (:if (core::log-or (core:streamp loop) (core:charp loop))
-                loop
-                ((:lambda (ch)
-                   (:if (mu:eof stream)
-                        stream
-                        (:if (mu:eq :wspace (core::read-char-syntax ch))
-                             (core:null loop)
-                             (:if (mu:eq ch #\#)
-                                  ((:lambda (ch)
-                                     (:if (mu:eq ch #\|)
-                                          (core::prog2
-                                             (core::read-sharp-comment ch stream)
-                                             (core:null loop))
-                                          (core::prog2
-                                             (core:unread-char ch stream)
-                                             #\#)))
-                                   (core:read-char stream () ()))
-                                  (:if (mu:eq ch #\;)
-                                       (core::prog2
-                                          (core::read-line-comment ch stream)
-                                          (core:null loop))
-                                       ch)))))
-                 (core:read-char stream () ()))))
-         ())))))
+  (:lambda (stream)
+    (core:errorp-unless core:streamp stream "core:read: not a stream")
+    ((:lambda (ch)
+       (:if (mu:eof stream)
+            ()
+            ((:lambda (macro)
+               (:if macro
+                    (core:apply (mu:car macro) (core::list2 stream ch))
+                    (core::read-dispatch ch stream)))
+             (core:get-macro-character ch))))
+     (core::read-consume-ws stream))))

--- a/src/core/strings.l
+++ b/src/core/strings.l
@@ -40,6 +40,29 @@
               ()))))
 
 ;;;
+;;; string-positionk
+;;;
+(mu:intern core::ns :extern "string-positionl"
+   (:lambda (fn str)
+     (core:errorp-unless core:functionp fn "core:string-positionl: not a function")           
+     (core:errorp-unless core:stringp str "core:string-positionl: not a string")
+     (:if (core:zerop (core:length str))
+          ()
+          ((:lambda (len)
+             (mu:car
+              (mu:fix
+               (:lambda (loop)
+                 (:if (core:listp loop)
+                      loop
+                      (:if (mu:fx-lt len loop)
+                           ()
+                           (:if (core:apply fn (core::list (mu:sv-ref str loop)))
+                                (core::list loop)
+                                (core:1+ loop)))))
+               0)))
+           (core:length str)))))
+
+;;;
 ;;; string construction
 ;;;
 (mu:intern core::ns :extern "string"

--- a/tests/core/read
+++ b/tests/core/read
@@ -3,11 +3,14 @@
 #
 assert_eq "(mu:type-of core:in-namespace)" ":func"
 assert_eq "(mu:type-of core:read)" ":func"
-assert_eq "(core:read (core:make-string-stream :input \"#xabc\") () ())" "2748"
+assert_eq "(core:read (core:make-string-stream :input \"'a\") () ())" "(:quote a)"
+assert_eq "(core:read (core:make-string-stream :input \"1024\") () ())" "1024"
+assert_eq "(core:read (core:make-string-stream :input \"1.024\") () ())" "1.024000"
+assert_eq "(core:read (core:make-string-stream :input \"#b10101100\") () ())" "172"
 assert_eq "(core:read (core:make-string-stream :input \"#d1024\") () ())" "1024"
+assert_eq "(core:read (core:make-string-stream :input \"#xabc\") () ())" "2748"
 assert_eq "(core:read (core:make-string-stream :input \"(1 2)\") () ())" "(1 2)"
 assert_eq "(core:read (core:make-string-stream :input \"(1 . 2)\") () ())" "(1 . 2)"
 assert_eq "(core:read (core:make-string-stream :input \"(1 2 . 3)\") () ())" "(1 2 . 3)"
 assert_eq "(core:read (core:make-string-stream :input \"((1 2) . 3)\") () ())" "((1 2) . 3)"
 assert_eq "(core:read (core:make-string-stream :input \"((1 2) . (3 4))\") () ())" "((1 2) 3 4)"
-#

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,4 +1,4 @@
-Test Summary: 02/23/2023 12:20:06
+Test Summary: 02/24/2023 16:54:00
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
 mu:        compile        total: 8        failed: 0        aborted: 0       
@@ -23,11 +23,11 @@ core:      format         total: 12       failed: 0        aborted: 0
 core:      lambda         total: 35       failed: 22       aborted: 0       
 core:      lists          total: 76       failed: 0        aborted: 1       
 core:      macro          total: 9        failed: 3        aborted: 0       
-core:      read           total: 9        failed: 7        aborted: 0       
+core:      read           total: 13       failed: 10       aborted: 0       
 core:      sequences      total: 3        failed: 0        aborted: 0       
 core:      streams        total: 23       failed: 0        aborted: 0       
 core:      strings        total: 16       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 219    total: 269      failed: 49       aborted: 1         
+core:      passed: 220    total: 273      failed: 52       aborted: 1         
 


### PR DESCRIPTION
Beat core::read-atom into submission

We can at least now read positive decimal fixnums.

Docs: no change
Tests: add a few core reader tests
Core: rewrite core::read-atom, implement core::parse-integer