### PR TITLE
#128 - core: remove date from test summary

### DIFF
--- a/tests/summary.py
+++ b/tests/summary.py
@@ -9,7 +9,7 @@ labels = [
 with open(sys.argv[1]) as f: test_results = f.readlines()
 date = datetime.now().strftime('%m/%d/%Y %H:%M:%S')
 
-print(f'Test Summary: {date:<10}')
+print(f'Test Summary:')
 print('-----------------------')
 
 for label in labels:

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,4 +1,4 @@
-Test Summary: 02/24/2023 19:12:07
+Test Summary:
 -----------------------
 mu:        chars          total: 2        failed: 0        aborted: 0       
 mu:        compile        total: 8        failed: 0        aborted: 0       


### PR DESCRIPTION
No more dates in summary output

Docs: no change
Tests: remove date output in summary script
Core: no change
Mu: no change