### PR TITLE
#131 - mu: fix end of byte stream processing

### DIFF
--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -23,11 +23,11 @@ core:      format         total: 12       failed: 0        aborted: 0
 core:      lambda         total: 35       failed: 22       aborted: 0       
 core:      lists          total: 76       failed: 0        aborted: 1       
 core:      macro          total: 9        failed: 3        aborted: 0       
-core:      reader         total: 18       failed: 15       aborted: 0       
+core:      reader         total: 18       failed: 10       aborted: 0       
 core:      sequences      total: 3        failed: 0        aborted: 0       
 core:      streams        total: 23       failed: 0        aborted: 0       
 core:      strings        total: 16       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 220    total: 278      failed: 57       aborted: 1         
+core:      passed: 225    total: 278      failed: 52       aborted: 1         
 


### PR DESCRIPTION
Fix eof-errop processing mu:rd-byte

Streamline dyad Makefile commit target, only print test diff

Docs: no change
Tests: voila, core reader number reader tests all clean up
Core: no change
Mu: make mu:rd-byte and mu:rd-char process eof the same way