### PR TITLE
#133 - mu: compile runtime with jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "dyad"
 version = "0.0.1"
 dependencies = [
@@ -17,7 +23,14 @@ dependencies = [
  "memmap",
  "modular-bitfield",
  "num_enum",
+ "tikv-jemallocator",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "getopt"
@@ -169,6 +182,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ getopt = "1.1.3"
 memmap = "0.7.0"
 modular-bitfield = "0.11.2"
 num_enum = "0.5.6"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.4.0"

--- a/src/mu/Cargo.toml
+++ b/src/mu/Cargo.toml
@@ -21,3 +21,6 @@ getopt = "1.1.3"
 memmap = "0.7.0"
 modular-bitfield = "0.11.2"
 num_enum = "0.5.6"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.4.0"

--- a/src/runtime/main.rs
+++ b/src/runtime/main.rs
@@ -2,6 +2,13 @@
 //  SPDX-License-Identifier: MIT
 
 //! runtime loader/repl
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 extern crate mu;
 
 use {


### PR DESCRIPTION
Link runtime with jemalloc, see about a 20% speedup running external tests

Docs: no change
Tests: no change
Mu: add jemalloc crate and boilerplate to runtime/main.rs
Core: no change