### PR TITLE
#124 - core: reader implementation - fixnums

### DIFF
--- a/src/core/read-macro.l
+++ b/src/core/read-macro.l
@@ -38,88 +38,59 @@
       ((:lambda (type)
           (core:errorp-unless mu:keyp type "core:read-sharp-vector: not a type keyword")
           (mu:vector type (core::read-list #\( stream)))
-       (core::read-atom stream))))
+       (core::read-atom ch stream))))
 
 (mu:intern core::ns :intern "read-sharp-symbol"
    (:lambda (ch stream)
      ((:lambda (symbol)
           (core:errorp-unless core:symbolp symbol "core::read-sharp-symbol: not a symbol")
           (mu:symbol (mu:sy-name symbol)))
-       (core::read-atom stream))))
+       (core::read-atom ch stream))))
 
 (mu:intern core::ns :intern "read-sharp-number"
-   (:lambda (base stream)
-     (mu:fix           
+  (:lambda (base stream)
+    (mu:fix           
       (:lambda (loop)
         (:if (core::logor (mu:eof stream) (core:numberp loop))
              loop
              ((:lambda (ch)
                 ((:lambda (syntax-type)
-                   (:if (mu:eq syntax-type 'constituent)
+                   (:if (mu:eq syntax-type :const)
                         (core::prog2
-                           (core:write-char ch core::reader-stream)
-                           (core:null loop))
+                            (core:write-char ch core::reader-stream)
+                            (core:null loop))
                         (core::prog2
-                           (:if (core:null ch)
-                                ()
-                                (core:unread-char ch stream))
-                           (:if (mu:eq base #\x)
-                                (mu::iparse (core:get-output-stream-string core::reader-stream) 16)
-                                (:if (mu:eq base #\b)
-                                     (mu::iparse (core:get-output-stream-string core::reader-stream) 2)
-                                     (mu::iparse (core:get-output-stream-string core::reader-stream) 10))))))
+                            (:if (core:null ch)
+                                 ()
+                                 (core:unread-char ch stream))
+                            (:if (mu:eq base #\x)
+                                 (core::parse-integer (mu:get-str core::reader-stream) 16)
+                                 (:if (mu:eq base #\b)
+                                      (core::parse-integer (mu:get-str core::reader-stream) 2)
+                                      (core::parse-integer (mu:get-str core::reader-stream) 10))))))
                  (core::read-char-syntax ch)))
               (core:read-char stream () ()))))
       ())))
    
 (mu:intern core::ns :intern "read-sharp"
-   (:lambda (ch stream)
-      ((:lambda (ch sharp-table)
-          (mu:apply
-            (mu:sy-val (mu:cdr (core:assoc ch sharp-table)))
-            (core::list2 ch stream)))
-       (core:read-char stream () ())
-       '((#\| . core::read-sharp-comment)
-         (#\\ . core::read-sharp-char)
-         (#\( . core::read-sharp-vector)
-         (#\b . core::read-sharp-number)
-         (#\x . core::read-sharp-number)
-         (#\d . core::read-sharp-number)
-         (#\: . core::read-sharp-symbol)))))
+  (:lambda (ch stream)
+    ((:lambda (ch sharp-table)
+       (mu:apply
+        (mu:sy-val (mu:cdr (core:assoc ch sharp-table)))
+        (core::list2 ch stream)))
+     (core:read-char stream () ())
+     '((#\| . core::read-sharp-comment)
+       (#\\ . core::read-sharp-char)
+       (#\( . core::read-sharp-vector)
+       (#\b . core::read-sharp-number)
+       (#\x . core::read-sharp-number)
+       (#\d . core::read-sharp-number)
+       (#\: . core::read-sharp-symbol)))))
 
 ;;;
 ;;; list reader
 ;;;
 (mu:intern core::ns :intern "read-list-eol" (mu:symbol "eol"))
-#|
-(mu:intern core::ns :intern "read-list"
-    (:lambda (ch stream)
-        (:if (mu:eq ch #\))
-             core::read-list-eol
-             (mu:fix
-              (:lambda (self eol list)
-                (:if eol
-                     list
-                     ((:lambda (form)
-                        (:if (mu:eq form core::read-list-eol)
-                             (mu:fr-setv (core::fn-frame-id self) 1 core::read-list-eol)
-                             (:if (core:symbolp form)
-                                  (:if (core::logand (core:uninternedp form) (mu:eq (mu:sy-name form) "."))
-                                       ((:lambda (dotted)
-                                          (core:error-if (core:null list) dotted "read-list: malformed dotted list")
-                                          ((:lambda (eol)
-                                             (:if (mu:eq eol core::read-list-eol)
-                                                  (core::prog2
-                                                     (mu:fr-setv (core::fn-frame-id self) 1 core::read-list-eol)
-                                                     (mu:fr-setv (core::fn-frame-id self) 2 (core::append list dotted)))
-                                                  (core:error eol "core::read-list: malformed dotted list")))
-                                           (core::read stream)))
-                                        (core::read stream))
-                                       (mu:fr-setv (core::fn-frame-id self) 2 (core::append list (core::list form))))
-                                  (mu:fr-setv (core::fn-frame-id self) 2 (core::append list (core::list form))))))
-                      (core::read stream))))
-              '(() ())))))
-|#
 
 (mu:intern core::ns :intern "read-list"
    (:lambda (ch stream)
@@ -188,12 +159,11 @@
 ;;; read macros
 ;;;
 (mu:intern core::ns :intern "read-macro"
-   (:lambda (stream)
-      ((:lambda (ch macro-table)
-          (mu:apply
+  (:lambda (ch stream)
+    ((:lambda (macro-table)
+       (mu:apply
             (mu:sy-val (mu:cdr (core:assoc ch macro-table)))
             (core::list2 ch stream)))
-       (core:read-char stream () ())
        '((#\" . core::read-string)
          (#\# . core::read-sharp)
          (#\' . core::read-quote)

--- a/src/core/read.l
+++ b/src/core/read.l
@@ -86,7 +86,6 @@
 
 (mu:intern core::ns :intern "read-number"
   (:lambda (atom)
-    (core:warn atom "read-number")
      ((:lambda (fx)
         (:if fx
              fx
@@ -97,48 +96,55 @@
 ;;; atom reader
 ;;;
 (mu:intern core::ns :intern "read-atom"
-   (:lambda (stream)
-    (core:errorp-when mu:eof stream "core::read-atom: unexpected eof")
-    (mu:car
-     (mu:fix
-      (:lambda (loop)
-        (:if (core:consp loop)
-             loop
-             (:if (mu:eof stream)
-                  ((:lambda (token)
-                     ((:lambda (number)
-                        (:if number
-                             (core::list number)
-                             (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
-                      (core::read-number token)))
-                   (core:get-output-stream-string core::reader-stream))
-                  ((:lambda (ch)
-                     (:if (mu:eq :const (core::read-char-syntax ch))
-                          ((:lambda ()
-                             (core:write-char ch core::reader-stream)
-                             (core:null loop)))
-                          (core::prog2
-                              (core:unread-char ch stream)
-                              ((:lambda (token)
-                                 ((:lambda (number)
-                                    (:if number
-                                         (core::list number)
-                                         (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
-                                  (core::read-number token)))
-                               (core:get-output-stream-string core::reader-stream)))))
-                   (core:read-char stream () ())))))
-      ()))))
+  (:lambda (ch stream)
+     (core:unread-char ch stream)
+     (mu:car
+      (mu:fix
+       (:lambda (loop)
+         (:if (core:consp loop)
+              loop
+              (:if (mu:eof stream)
+                   ((:lambda (token)
+                      ((:lambda (number)
+                         (:if number
+                              (core::list number)
+                              (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
+                       (core::read-number token)))
+                    (core:get-output-stream-string core::reader-stream))
+                   ((:lambda (ch)
+                      (:if (core:null ch)
+                           ((:lambda (token)
+                              ((:lambda (number)
+                                 (:if number
+                                      (core::list number)
+                                      (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
+                               (core::read-number token)))
+                            (core:get-output-stream-string core::reader-stream))
+                           (:if (mu:eq :const (core::read-char-syntax ch))
+                                (core::prog2
+                                    (core:write-char ch core::reader-stream)
+                                    (core:null loop))
+                                (core::prog2
+                                    (core:unread-char ch stream)
+                                    ((:lambda (token)
+                                       ((:lambda (number)
+                                          (:if number
+                                               (core::list number)
+                                               (core::list (core::symbol-macro-expand (core::read-resolve-symbol token)))))
+                                        (core::read-number token)))
+                                     (core:get-output-stream-string core::reader-stream))))))
+                    (core:read-char stream () ())))))
+       ()))))
 
 ;;;
 ;;; parser
 ;;;
 (mu:intern core::ns :intern "read-dispatch"
    (:lambda (ch stream)
-     (core:unread-char ch stream)
      ((:lambda (dispatch-table)
         (mu:apply
          (mu:sy-val (mu:cdr (core:assoc (core::read-char-syntax ch) dispatch-table)))
-         (core::list stream)))
+         (core::list2 ch stream)))
       '((:const   . core::read-atom)
         (:escape  . core::read-atom)
         (:macro   . core::read-macro)
@@ -146,36 +152,36 @@
         (:mescape . core::read-atom)))))
 
 ;;;
-;;; core reader
+;;; consaume whitespace and comments
 ;;;
 (mu:intern core::ns :intern "read-consume-ws"
-   (:lambda (stream)
-     (mu:fix
-      (:lambda (loop)
-        (:if (core::logor (core:streamp loop) (core:charp loop))
-             loop
-             ((:lambda (ch)
-                (:if (core:null ch)
-                     stream
-                     (:if (mu:eq :wspace (core::read-char-syntax ch))
-                          (core:null loop)
-                          (:if (mu:eq ch #\#)
-                               ((:lambda (ch)
-                                  (:if (mu:eq ch #\|)
-                                       (core::prog2
+  (:lambda (stream)
+    (mu:fix
+     (:lambda (loop)
+       (:if (core::logor (core:streamp loop) (core:charp loop))
+            loop
+            ((:lambda (ch)
+               (:if (core:null ch)
+                    stream
+                    (:if (mu:eq :wspace (core::read-char-syntax ch))
+                         (core:null loop)
+                         (:if (mu:eq ch #\#)
+                              ((:lambda (ch)
+                                 (:if (mu:eq ch #\|)
+                                      (core::prog2
                                           (core::read-sharp-comment ch stream)
                                           (core:null loop))
-                                       (core::prog2
+                                      (core::prog2
                                           (core:unread-char ch stream)
                                           #\#)))
-                                (core:read-char stream () ()))
-                               (:if (mu:eq ch #\;)
-                                    (core::prog2
+                               (core:read-char stream () ()))
+                              (:if (mu:eq ch #\;)
+                                   (core::prog2
                                        (core::read-line-comment ch stream)
                                        (core:null loop))
-                                    ch)))))
-              (core:read-char stream () ()))))
-      ())))
+                                   ch)))))
+             (core:read-char stream () ()))))
+     ())))
 
 ;;;
 ;;; recursive reader

--- a/src/core/streams.l
+++ b/src/core/streams.l
@@ -58,18 +58,18 @@
      (mu:wr-byte byte (core::write-stream-designator designator))))
 
 (mu:intern core::ns :extern "read-char"
-   (:lambda (designator error-eofp eof-value)
-     ((:lambda (stream)
-        (:if (mu:eof stream)
-             (:if error-eofp
-                  (core:error stream "core:read-char: end of file")
-                  eof-value)
-             ((:lambda (ch)
-                (:if ch
-                     (mu:coerce ch :char)
-                     ()))
-              (mu:rd-byte stream () ()))))
-      (core::read-stream-designator designator))))
+  (:lambda (designator error-eofp eof-value)
+    ((:lambda (stream)
+       ((:lambda (ch)
+          (:if (core:null ch)
+               (:if error-eofp
+                    (core:error stream "core:read-char: end of file")
+                    eof-value)
+               (core::prog2
+                   (core:warn ch "core:read-char")
+                   ch)))
+        (mu:rd-char stream () ())))
+     (core::read-stream-designator designator))))
 
 (mu:intern core::ns :extern "read-byte"
    (:lambda (designator error-eofp eof-value)
@@ -83,11 +83,13 @@
 
 (mu:intern core::ns :extern "unread-char"
   (:lambda (char designator)
+    (core:warn char "core:unread-char")
     (core:errorp-unless core:charp char "core:unread-char: not a char")
     (mu:un-char char (core::write-stream-designator designator))))
 
 (mu:intern core::ns :extern "unread-byte"
   (:lambda (byte designator)
+    (core:warn byte "core:unread-byte")
     (core:errorp-unless core:fixnump char "core:unead-byte: not a byte")
     (mu:un-byte byte (core::write-stream-designator designator))))
 

--- a/src/mu/types/stream.rs
+++ b/src/mu/types/stream.rs
@@ -774,19 +774,10 @@ impl MuFunction for Stream {
             Type::Stream => match Self::read_byte(mu, stream) {
                 Ok(Some(byte)) => Fixnum::as_tag(byte as i64),
                 Ok(None) if erreofp.null_() => eof_value,
-                Ok(None) => {
-                    return Err(Exception::raise(mu, Condition::Eof, "mu:read-byte", stream))
-                }
+                Ok(None) => return Err(Exception::raise(mu, Condition::Eof, "mu:rd-byte", stream)),
                 Err(e) => return Err(e),
             },
-            _ => {
-                return Err(Exception::raise(
-                    mu,
-                    Condition::Type,
-                    "mu:read-byte",
-                    stream,
-                ))
-            }
+            _ => return Err(Exception::raise(mu, Condition::Type, "mu:rd-byte", stream)),
         };
 
         Ok(())
@@ -818,7 +809,7 @@ impl MuFunction for Stream {
         match Tag::type_of(mu, stream) {
             Type::Stream => match Self::unread_char(mu, stream, Char::as_char(mu, ch)) {
                 Ok(Some(_)) => {
-                    panic!("internal: unexpected return from unread_char")
+                    panic!("internal: unexpected return from mu_unread_char")
                 }
                 Ok(None) => {
                     fp.value = ch;

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -23,11 +23,11 @@ core:      format         total: 12       failed: 0        aborted: 0
 core:      lambda         total: 35       failed: 22       aborted: 0       
 core:      lists          total: 76       failed: 0        aborted: 1       
 core:      macro          total: 9        failed: 3        aborted: 0       
-core:      reader         total: 18       failed: 10       aborted: 0       
+core:      reader         total: 18       failed: 7        aborted: 0       
 core:      sequences      total: 3        failed: 0        aborted: 0       
 core:      streams        total: 23       failed: 0        aborted: 0       
 core:      strings        total: 16       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 225    total: 278      failed: 52       aborted: 1         
+core:      passed: 228    total: 278      failed: 49       aborted: 1         
 


### PR DESCRIPTION
Rework a lot of the core reader, fixnums in various bases work

Docs: no change
Tests: no change, core reader fixnum tests pass
Core: rewrite parts of  read-consume-ws, read-dispatch, and read-macro
Mu: make unreads work


