### PR TITLE
#153 - core: closure cleanup

### DIFF
--- a/src/core/closures.l
+++ b/src/core/closures.l
@@ -11,6 +11,7 @@
 ;;;
 (mu:intern core::ns :intern "closure-prop"
   (:lambda (key closure)
+    (core:errorp-unless core:closurep closure "core::closure-prop: is not a closure")           
     (mu:sv-ref
      (mu:st-vec closure)
      (mu:cdr
@@ -42,8 +43,8 @@
 
 (mu:intern core::ns :intern "lambda-arg-list"
    (:lambda (fn args)
-     (:if (core::fn-restp fn)
-          (:if (core:zerop (core::fn-nreqs fn))
+     (:if (core::closurep fn)
+          (:if (core::logand (core:closure-prop :rest fn) (core:zerop (core::closure-prop :arity fn)))
                (core::list3 'mu:cons (core::flat-arg-list args) ())
                ((:lambda (reqs rest)
                   (mu:cons 'core::append
@@ -54,21 +55,21 @@
                                 (core::flat-arg-list rest)
                                 (core::list ())))
                                         ()))))
-                   (core:dropr args (mu:fx-sub (mu:length args) (core::fn-nreqs fn)))
-                   (core:dropl args (core::fn-nreqs fn))))
+                   (core:dropr args (mu:fx-sub (mu:length args) (core::closure-prop :arity fn)))
+                   (core:dropl args (core::closure-prop :arity fn))))
           (core::flat-arg-list args))))
 
 (mu:intern core::ns :intern "quoted-lambda-arg-list"
    (:lambda (fn args)
-     (:if (core::fn-restp fn)
-          (:if (core:zerop (core::fn-nreqs fn))
+     (:if (core::closure-prop :rest fn)
+          (:if (core::logand (core:closure-prop :rest fn) (core:zerop (core::closure-prop :arity fn)))
                (core::list args)
                ((:lambda (reqs rest)
                   (core::append
                    reqs
                    (core::list rest)))
-                (core:dropr args (mu:fx-sub (mu:length args) (core::fn-nreqs fn)))
-                (core:dropl args (core::fn-nreqs fn))))
+                (core:dropr args (mu:fx-sub (mu:length args) (core::closure-prop :arity fn)))
+                (core:dropl args (core::closure-prop :arity fn))))
           args)))
 
 ;;;
@@ -142,7 +143,7 @@
   (:lambda (symbol args env)
     (:if (core:boundp symbol)
          ((:lambda (fn)
-            (:if (core::fn-lambda-desc fn)
+            (:if (core::lambda-prop :desc fn)
                  (core::list3 core:apply fn (core::compile-flat-arg-list args env))
                  (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env))))
           (core:symbol-value (core::compile symbol env)))

--- a/src/core/lambda.l
+++ b/src/core/lambda.l
@@ -77,6 +77,8 @@
 (mu:intern core::ns :intern "compile-lambda"
    (:lambda (form env)
      ((:lambda (lambda-desc body)
+        (core:warn lambda-desc "compile-lambda:")
+        (core:warn body "compile-lambda:")
         (mu:compile
            (mu:cons :lambda
               (mu:cons (core::lambda-prop :symbols lambda-desc)
@@ -88,7 +90,8 @@
 ;;; compile a closure
 ;;;
 (mu:intern core::ns :intern "closure"
-   (:lambda (fn)
+  (:lambda (fn)
+     (core:warn fn "closure:")           
      ((:lambda (lambda-desc)
         (core:errorp-when core:null lambda-desc "core::closure: closing bare function")
         ((:lambda (desc body)
@@ -102,7 +105,7 @@
           (core::lambda-prop :reqsyms lambda-desc)
           (core::lambda-prop :restsym lambda-desc)
           (core::lambda-prop :env lambda-desc)
-          (core:mapcar (:lambda (desc-) (mu:fr-get (core::lambda-prop :frame desc-)))
+          (core:mapcar (:lambda (desc) (mu:fr-get (core::lambda-prop :frame desc)))
                        (core::lambda-prop :env lambda-desc)))
          (mu:cdr (core::fn-form fn))))
         (core::fn-lambda-desc fn))))
@@ -111,7 +114,9 @@
 ;;; [*closure-descriptor*] `(function . values)` 
 ;;;
 (mu:intern core::ns :intern "compile-closure"
-  (:lambda (form env)
+  (:lambda (lambda-desc form env)
+    (core:warn lambda-desc "compile-closure:")
+    (core:warn form "compile-closure:")
     (core:maplist
      (:lambda (form-cons)
        ((:lambda (compiled-form)
@@ -136,9 +141,10 @@
 ;;;
 (mu:intern core::ns :intern "compile-lambda-body"
   (:lambda (lambda-desc body env)
+    (core:warn lambda-desc "compile-lambda-body:")
     (:if body
          ((:lambda (env)
-              (core::compile-closure (mu:cons lambda-desc body) env))
+              (core::compile-closure lambda-desc body env))
             (core::compile-add-env lambda-desc env))
            ())))
 

--- a/tests/core/closures
+++ b/tests/core/closures
@@ -2,12 +2,6 @@
 # core closure tests
 #
 assert_eq "(mu:type-of core:apply)" ":func"
-assert_eq "(mu:type-of core::fn-arity)" ":func"
-assert_eq "(mu:type-of core::fn-frame-id)" ":func"
-assert_eq "(mu:type-of core::fn-form)" ":func"
-assert_eq "(mu:type-of core::fn-lambda-desc)" ":func"
-assert_eq "(mu:type-of core::fn-nreqs)" ":func"
-assert_eq "(mu:type-of core::fn-restp)" ":func"
 assert_eq "(mu:eval (core:compile '((lambda () (defun core:a-defun () 'a-defun) (core:a-defun)))))" "a-defun"
 assert_eq "(mu:eval (core:compile '((lambda () (defun core:a-defun (a) a) (core:a-defun 'a-defun)))))" "a-defun"
 assert_eq "(mu:eval (core:compile '((lambda () (defun core:a-defun (a b) (mu:cons a b)) (core:a-defun 'a-defun 'b-defun)))))" "(a-defun . b-defun)"

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -15,7 +15,7 @@ mu:        vectors        total: 23       failed: 0        aborted: 0
 -----------------------
 mu:        passed: 219    total: 219      failed: 0        aborted: 0         
 
-core:      closures       total: 14       failed: 13       aborted: 0       
+core:      closures       total: 8        failed: 7        aborted: 0       
 core:      compile        total: 30       failed: 4        aborted: 0       
 core:      core           total: 22       failed: 0        aborted: 0       
 core:      exceptions     total: 7        failed: 0        aborted: 0       
@@ -29,5 +29,5 @@ core:      streams        total: 22       failed: 0        aborted: 0
 core:      strings        total: 20       failed: 0        aborted: 0       
 core:      vectors        total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 268    total: 315      failed: 46       aborted: 1         
+core:      passed: 268    total: 309      failed: 40       aborted: 1         
 


### PR DESCRIPTION
Work on closure representation, amend the closure tests

Doc: no change
Tests: revise closure tests
Core: replace the fn- accessors with closure accessors (mostly)
Mu: no change