### PR TITLE
#175 - core: exception reporting

### DIFF
--- a/src/mu/core/exception.rs
+++ b/src/mu/core/exception.rs
@@ -144,7 +144,7 @@ impl MuFunction for Exception {
                 Type::Function => match mu.apply(thunk, Tag::nil()) {
                     Ok(v) => v,
                     Err(e) => {
-                        let args = vec![Self::map_condkey(e.condition).unwrap(), e.tag];
+                        let args = vec![e.tag, Self::map_condkey(e.condition).unwrap()];
                         match mu.apply(handler, Cons::list(mu, &args)) {
                             Ok(v) => v,
                             Err(e) => return Err(e),

--- a/src/runtime/main.rs
+++ b/src/runtime/main.rs
@@ -149,8 +149,8 @@ fn load(mu: &Mu, path: &str, debug: bool) -> Option<()> {
                             }
                             Err(e) => {
                                 eprint!(
-                                    "exception: (load eval) raised from {1}, {:?} condition on ",
-                                    e.condition, e.source
+                                    "exception: (load eval) raised from {:?}, {:?} condition on ",
+                                    e.source, e.condition
                                 );
                                 mu.write(e.tag, true, mu.errout).unwrap();
                                 break;
@@ -159,8 +159,8 @@ fn load(mu: &Mu, path: &str, debug: bool) -> Option<()> {
                     }
                     Err(e) => {
                         eprint!(
-                            "exception: (load compile) raised from {1}, {:?} condition on ",
-                            e.condition, e.source
+                            "exception: (load compile) raised from {:?}, {:?} condition on ",
+                            e.source, e.condition
                         );
                         mu.write(e.tag, true, mu.errout).unwrap();
                         break;
@@ -266,8 +266,8 @@ pub fn main() {
                             Ok(eval) => mu.write(eval, false, mu.stdout).unwrap(),
                             Err(e) => {
                                 eprint!(
-                                    "exception: raised from {1}, {:?} condition on ",
-                                    e.condition, e.source
+                                    "exception: raised from {:?}, {:?} condition on ",
+                                    e.source, e.condition
                                 );
                                 mu.write(e.tag, true, mu.errout).unwrap()
                             }


### PR DESCRIPTION
Make core, runtime, and doc all agree on the order of arguments to with-ex exception function

Doc: no change
Tests: no change
Core: change repl with-ex handler
runtime: print exception in the right order