### PR TITLE
#190 - tests: enhance core symbol reader tests

### DIFF
--- a/tests/core/reader
+++ b/tests/core/reader
@@ -4,6 +4,12 @@
 assert_eq "(mu:type-of core:in-namespace)" ":func"
 assert_eq "(mu:type-of core:read)" ":func"
 # symbols
+assert_eq '(mu:sy-name (core:read (core:make-string-stream :input "a") () ()))' '"a"'
+assert_eq '(mu:sy-name (core:read (core:make-string-stream :input "core::a") () ()))' '"a"'
+assert_eq '(mu:sy-name (core:read (core:make-string-stream :input "core:a") () ()))' '"a"'
+assert_eq '(mu:sy-ns (core:read (core:make-string-stream :input "a") () ()))' '#<namespace: "">'
+assert_eq '(mu:sy-ns (core:read (core:make-string-stream :input "core::a") () ()))' '#<namespace: "core">'
+assert_eq '(mu:sy-ns (core:read (core:make-string-stream :input "core:a") () ()))' '#<namespace: "core">'
 assert_eq "(core:read (core:make-string-stream :input \"a\") () ())" "a"
 assert_eq "(core:read (core:make-string-stream :input \"core:a\") () ())" "core:a"
 assert_eq "(core:read (core:make-string-stream :input \"abc\") () ())" "abc"

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -23,11 +23,11 @@ core:      format         total: 12       failed: 0        aborted: 0
 core:      lambda         total: 35       failed: 20       aborted: 0       
 core:      list           total: 78       failed: 0        aborted: 0       
 core:      macro          total: 9        failed: 3        aborted: 0       
-core:      reader         total: 52       failed: 4        aborted: 0       
+core:      reader         total: 58       failed: 4        aborted: 0       
 core:      sequence       total: 3        failed: 0        aborted: 0       
 core:      stream         total: 22       failed: 0        aborted: 0       
 core:      string         total: 20       failed: 0        aborted: 0       
 core:      vector         total: 13       failed: 0        aborted: 0       
 -----------------------
-core:      passed: 276    total: 314      failed: 38       aborted: 0         
+core:      passed: 282    total: 320      failed: 38       aborted: 0         
 


### PR DESCRIPTION
add namespace and base name tests to symbol reader tests

Docs: no change
Tests: add half a dozen tests to core/reader
Core: no change